### PR TITLE
Change brave-search to use their free AI API search offering

### DIFF
--- a/brave-search/SKILL.md
+++ b/brave-search/SKILL.md
@@ -5,25 +5,48 @@ description: Web search and content extraction via Brave Search API. Use for sea
 
 # Brave Search
 
-Headless web search and content extraction using Brave Search. No browser required.
+Web search and content extraction using the official Brave Search API. No browser required.
 
 ## Setup
 
-Run once before first use:
+Requires a Brave Search API account with a free subscription. A credit card is required to create the free subscription (you won't be charged).
 
-```bash
-cd {baseDir}/brave-search
-npm install
-```
+1. Create an account at https://api-dashboard.search.brave.com/register
+2. Create a "Free AI" subscription
+3. Create an API key for the subscription
+4. Add to your shell profile (`~/.profile` or `~/.zprofile` for zsh):
+   ```bash
+   export BRAVE_API_KEY="your-api-key-here"
+   ```
+5. Install dependencies (run once):
+   ```bash
+   cd {baseDir}
+   npm install
+   ```
 
 ## Search
 
 ```bash
-{baseDir}/search.js "query"                    # Basic search (5 results)
-{baseDir}/search.js "query" -n 10              # More results
-{baseDir}/search.js "query" --content          # Include page content as markdown
-{baseDir}/search.js "query" -n 3 --content     # Combined
+{baseDir}/search.js "query"                         # Basic search (5 results)
+{baseDir}/search.js "query" -n 10                   # More results (max 20)
+{baseDir}/search.js "query" --content               # Include page content as markdown
+{baseDir}/search.js "query" --freshness pw          # Results from last week
+{baseDir}/search.js "query" --freshness 2024-01-01to2024-06-30  # Date range
+{baseDir}/search.js "query" --country DE            # Results from Germany
+{baseDir}/search.js "query" -n 3 --content          # Combined options
 ```
+
+### Options
+
+- `-n <num>` - Number of results (default: 5, max: 20)
+- `--content` - Fetch and include page content as markdown
+- `--country <code>` - Two-letter country code (default: US)
+- `--freshness <period>` - Filter by time:
+  - `pd` - Past day (24 hours)
+  - `pw` - Past week
+  - `pm` - Past month
+  - `py` - Past year
+  - `YYYY-MM-DDtoYYYY-MM-DD` - Custom date range
 
 ## Extract Page Content
 
@@ -39,6 +62,7 @@ Fetches a URL and extracts readable content as markdown.
 --- Result 1 ---
 Title: Page Title
 Link: https://example.com/page
+Age: 2 days ago
 Snippet: Description from search results
 Content: (if --content flag used)
   Markdown content extracted from the page...

--- a/brave-search/search.js
+++ b/brave-search/search.js
@@ -18,75 +18,92 @@ if (nIndex !== -1 && args[nIndex + 1]) {
 	args.splice(nIndex, 2);
 }
 
+// Parse country option
+let country = "US";
+const countryIndex = args.indexOf("--country");
+if (countryIndex !== -1 && args[countryIndex + 1]) {
+	country = args[countryIndex + 1].toUpperCase();
+	args.splice(countryIndex, 2);
+}
+
+// Parse freshness option
+let freshness = null;
+const freshnessIndex = args.indexOf("--freshness");
+if (freshnessIndex !== -1 && args[freshnessIndex + 1]) {
+	freshness = args[freshnessIndex + 1];
+	args.splice(freshnessIndex, 2);
+}
+
 const query = args.join(" ");
 
 if (!query) {
-	console.log("Usage: search.js <query> [-n <num>] [--content]");
+	console.log("Usage: search.js <query> [-n <num>] [--content] [--country <code>] [--freshness <period>]");
 	console.log("\nOptions:");
-	console.log("  -n <num>    Number of results (default: 5)");
-	console.log("  --content   Fetch readable content as markdown");
+	console.log("  -n <num>              Number of results (default: 5, max: 20)");
+	console.log("  --content             Fetch readable content as markdown");
+	console.log("  --country <code>      Country code for results (default: US)");
+	console.log("  --freshness <period>  Filter by time: pd (day), pw (week), pm (month), py (year)");
+	console.log("\nEnvironment:");
+	console.log("  BRAVE_API_KEY         Required. Your Brave Search API key.");
 	console.log("\nExamples:");
 	console.log('  search.js "javascript async await"');
 	console.log('  search.js "rust programming" -n 10');
 	console.log('  search.js "climate change" --content');
+	console.log('  search.js "news today" --freshness pd');
 	process.exit(1);
 }
 
-async function fetchBraveResults(query, numResults) {
-	const url = `https://search.brave.com/search?q=${encodeURIComponent(query)}`;
-	
+const apiKey = process.env.BRAVE_API_KEY;
+if (!apiKey) {
+	console.error("Error: BRAVE_API_KEY environment variable is required.");
+	console.error("Get your API key at: https://api-dashboard.search.brave.com/app/keys");
+	process.exit(1);
+}
+
+async function fetchBraveResults(query, numResults, country, freshness) {
+	const params = new URLSearchParams({
+		q: query,
+		count: Math.min(numResults, 20).toString(),
+		country: country,
+	});
+
+	if (freshness) {
+		params.append("freshness", freshness);
+	}
+
+	const url = `https://api.search.brave.com/res/v1/web/search?${params.toString()}`;
+
 	const response = await fetch(url, {
 		headers: {
-			"User-Agent": "Mozilla/5.0 (Macintosh; Intel Mac OS X 10_15_7) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/142.0.0.0 Safari/537.36",
-			"Accept": "text/html,application/xhtml+xml,application/xml;q=0.9,image/avif,image/webp,image/apng,*/*;q=0.8",
-			"Accept-Language": "en-US,en;q=0.9",
-			"sec-ch-ua": '"Chromium";v="142", "Google Chrome";v="142", "Not_A Brand";v="99"',
-			"sec-ch-ua-mobile": "?0",
-			"sec-ch-ua-platform": '"macOS"',
-			"sec-fetch-dest": "document",
-			"sec-fetch-mode": "navigate",
-			"sec-fetch-site": "none",
-			"sec-fetch-user": "?1",
+			"Accept": "application/json",
+			"Accept-Encoding": "gzip",
+			"X-Subscription-Token": apiKey,
 		}
 	});
-	
+
 	if (!response.ok) {
-		throw new Error(`HTTP ${response.status}: ${response.statusText}`);
+		const errorText = await response.text();
+		throw new Error(`HTTP ${response.status}: ${response.statusText}\n${errorText}`);
 	}
-	
-	const html = await response.text();
-	const dom = new JSDOM(html);
-	const doc = dom.window.document;
-	
+
+	const data = await response.json();
+
 	const results = [];
-	
-	// Find all search result snippets with data-type="web"
-	const snippets = doc.querySelectorAll('div.snippet[data-type="web"]');
-	
-	for (const snippet of snippets) {
-		if (results.length >= numResults) break;
-		
-		// Get the main link and title
-		const titleLink = snippet.querySelector('a.svelte-14r20fy');
-		if (!titleLink) continue;
-		
-		const link = titleLink.getAttribute('href');
-		if (!link || link.includes('brave.com')) continue;
-		
-		const titleEl = titleLink.querySelector('.title');
-		const title = titleEl?.textContent?.trim() || titleLink.textContent?.trim() || '';
-		
-		// Get the snippet/description
-		const descEl = snippet.querySelector('.generic-snippet .content');
-		let snippetText = descEl?.textContent?.trim() || '';
-		// Remove date prefix if present
-		snippetText = snippetText.replace(/^[A-Z][a-z]+ \d+, \d{4} -\s*/, '');
-		
-		if (title && link) {
-			results.push({ title, link, snippet: snippetText });
+
+	// Extract web results
+	if (data.web && data.web.results) {
+		for (const result of data.web.results) {
+			if (results.length >= numResults) break;
+
+			results.push({
+				title: result.title || "",
+				link: result.url || "",
+				snippet: result.description || "",
+				age: result.age || result.page_age || "",
+			});
 		}
 	}
-	
+
 	return results;
 }
 
@@ -116,31 +133,31 @@ async function fetchPageContent(url) {
 			},
 			signal: AbortSignal.timeout(10000),
 		});
-		
+
 		if (!response.ok) {
 			return `(HTTP ${response.status})`;
 		}
-		
+
 		const html = await response.text();
 		const dom = new JSDOM(html, { url });
 		const reader = new Readability(dom.window.document);
 		const article = reader.parse();
-		
+
 		if (article && article.content) {
 			return htmlToMarkdown(article.content).substring(0, 5000);
 		}
-		
+
 		// Fallback: try to get main content
 		const fallbackDoc = new JSDOM(html, { url });
 		const body = fallbackDoc.window.document;
 		body.querySelectorAll("script, style, noscript, nav, header, footer, aside").forEach(el => el.remove());
 		const main = body.querySelector("main, article, [role='main'], .content, #content") || body.body;
 		const text = main?.textContent || "";
-		
+
 		if (text.trim().length > 100) {
 			return text.trim().substring(0, 5000);
 		}
-		
+
 		return "(Could not extract content)";
 	} catch (e) {
 		return `(Error: ${e.message})`;
@@ -149,24 +166,27 @@ async function fetchPageContent(url) {
 
 // Main
 try {
-	const results = await fetchBraveResults(query, numResults);
-	
+	const results = await fetchBraveResults(query, numResults, country, freshness);
+
 	if (results.length === 0) {
 		console.error("No results found.");
 		process.exit(0);
 	}
-	
+
 	if (fetchContent) {
 		for (const result of results) {
 			result.content = await fetchPageContent(result.link);
 		}
 	}
-	
+
 	for (let i = 0; i < results.length; i++) {
 		const r = results[i];
 		console.log(`--- Result ${i + 1} ---`);
 		console.log(`Title: ${r.title}`);
 		console.log(`Link: ${r.link}`);
+		if (r.age) {
+			console.log(`Age: ${r.age}`);
+		}
 		console.log(`Snippet: ${r.snippet}`);
 		if (r.content) {
 			console.log(`Content:\n${r.content}`);


### PR DESCRIPTION
Brave web searches frequently get rate-limited when using headless searches against their browser endpoint.

This change uses their dedicated search API endpoint that is free to use for AI inference.