### PR TITLE
Fix browser-nav when no tabs exist

### DIFF
--- a/browser-tools/browser-nav.js
+++ b/browser-tools/browser-nav.js
@@ -30,7 +30,11 @@ if (newTab) {
 	await p.goto(url, { waitUntil: "domcontentloaded" });
 	console.log("✓ Opened:", url);
 } else {
-	const p = (await b.pages()).at(-1);
+	const pages = await b.pages();
+	let p = pages.at(-1);
+	if (!p) {
+		p = await b.newPage();
+	}
 	await p.goto(url, { waitUntil: "domcontentloaded" });
 	console.log("✓ Navigated to:", url);
 }


### PR DESCRIPTION
 - Handle the case where Chrome has no open pages by creating a new tab before navigating
 - Prevents `Cannot read properties of undefined (reading 'goto')`-errors when eg. starting with `--profile`