### PR TITLE
Add Emacs context skill

### DIFF
--- a/README.md
+++ b/README.md
@@ -50,6 +50,7 @@ git clone https://github.com/badlogic/pi-skills ~/pi-skills
 mkdir -p ~/.claude/skills
 ln -s ~/pi-skills/brave-search ~/.claude/skills/brave-search
 ln -s ~/pi-skills/browser-tools ~/.claude/skills/browser-tools
+ln -s ~/pi-skills/emacs ~/.claude/skills/emacs
 ln -s ~/pi-skills/gccli ~/.claude/skills/gccli
 ln -s ~/pi-skills/gdcli ~/.claude/skills/gdcli
 ln -s ~/pi-skills/gmcli ~/.claude/skills/gmcli
@@ -61,6 +62,7 @@ ln -s ~/pi-skills/youtube-transcript ~/.claude/skills/youtube-transcript
 mkdir -p .claude/skills
 ln -s ~/pi-skills/brave-search .claude/skills/brave-search
 ln -s ~/pi-skills/browser-tools .claude/skills/browser-tools
+ln -s ~/pi-skills/emacs .claude/skills/emacs
 ln -s ~/pi-skills/gccli .claude/skills/gccli
 ln -s ~/pi-skills/gdcli .claude/skills/gdcli
 ln -s ~/pi-skills/gmcli .claude/skills/gmcli
@@ -75,6 +77,7 @@ ln -s ~/pi-skills/youtube-transcript .claude/skills/youtube-transcript
 |-------|-------------|
 | [brave-search](brave-search/SKILL.md) | Web search and content extraction via Brave Search |
 | [browser-tools](browser-tools/SKILL.md) | Interactive browser automation via Chrome DevTools Protocol |
+| [emacs](emacs/SKILL.md) | Emacs integration for selection and buffer context |
 | [gccli](gccli/SKILL.md) | Google Calendar CLI for events and availability |
 | [gdcli](gdcli/SKILL.md) | Google Drive CLI for file management and sharing |
 | [gmcli](gmcli/SKILL.md) | Gmail CLI for email, drafts, and labels |
@@ -106,6 +109,7 @@ Some skills require additional setup. Generally, the agent will walk you through
 
 - **brave-search**: Requires Node.js. Run `npm install` in the skill directory.
 - **browser-tools**: Requires Chrome and Node.js. Run `npm install` in the skill directory.
+- **emacs**: Requires Emacs with server running and `emacsclient` in PATH.
 - **gccli**: Requires Node.js. Install globally with `npm install -g @mariozechner/gccli`.
 - **gdcli**: Requires Node.js. Install globally with `npm install -g @mariozechner/gdcli`.
 - **gmcli**: Requires Node.js. Install globally with `npm install -g @mariozechner/gmcli`.

--- a/emacs/SKILL.md
+++ b/emacs/SKILL.md
@@ -1,0 +1,46 @@
+---
+name: emacs
+description: Emacs integration for capturing current selection, buffer, and persp context via emacsclient. Use when working in Emacs and need editor context.
+---
+
+# Emacs Integration
+
+Use `emacsclient` to query the active Emacs session for context: buffer, selection, cursor, and buffer list (optionally scoped to persp-mode). It prefers the buffer with an active region and falls back to the selected window buffer.
+
+## Requirements
+
+- Emacs server running (`M-x server-start` or `emacs --daemon`)
+- `emacsclient` available in PATH
+- Emacs 27+ (for `json-serialize`)
+
+## Detecting Emacs
+
+When running inside Emacs/vterm, environment variables are usually set:
+
+```bash
+echo $INSIDE_EMACS
+echo $TERM_PROGRAM
+```
+
+Verify the server is reachable:
+
+```bash
+emacsclient --eval "(emacs-version)"
+```
+
+## Get Current Context
+
+```bash
+{baseDir}/scripts/context.sh
+```
+
+Outputs JSON to stdout with:
+
+- `buffer`: active-region buffer (if any) or selected window buffer (name, file, mode, modified, active)
+- `cursor`: line/column
+- `selection`: selected text and range (empty object when no active region)
+- `persp`: current persp name (if persp-mode is loaded)
+- `project`: project root (if project.el is available)
+- `buffers`: file-backed buffers in the current persp (or all buffers when no persp)
+
+If you have a region active in another buffer (e.g., you are in vterm but selected text in a file buffer), the selection and `buffer` fields will reflect that active region.

--- a/emacs/scripts/context.el
+++ b/emacs/scripts/context.el
@@ -1,0 +1,94 @@
+;;; pi-emacs-context.el --- Export Emacs editor context for pi -*- lexical-binding: t; -*-
+
+(require 'cl-lib)
+(require 'json)
+
+(defun pi-emacs--maybe-persp ()
+  (when (and (featurep 'persp-mode) (fboundp 'get-current-persp))
+    (get-current-persp)))
+
+(defun pi-emacs--current-persp-name ()
+  (let ((persp (pi-emacs--maybe-persp)))
+    (when (and persp (fboundp 'persp-name))
+      (persp-name persp))))
+
+(defun pi-emacs--persp-buffers (persp)
+  (cond
+   ((and persp (fboundp 'persp-buffers)) (persp-buffers persp))
+   ((and persp (fboundp 'persp-buffer-list)) (persp-buffer-list persp))
+   ((and persp (fboundp 'persp-current-buffers)) (persp-current-buffers persp))
+   (t nil)))
+
+(defun pi-emacs--candidate-buffers ()
+  (or (pi-emacs--persp-buffers (pi-emacs--maybe-persp))
+      (buffer-list)))
+
+(defun pi-emacs--buffer-with-active-region ()
+  (cl-find-if (lambda (buf)
+                (with-current-buffer buf
+                  (use-region-p)))
+              (pi-emacs--candidate-buffers)))
+
+(defun pi-emacs--project-root ()
+  (when (and (fboundp 'project-current) (fboundp 'project-root))
+    (let ((project (project-current nil)))
+      (when project
+        (project-root project)))))
+
+(defun pi-emacs--selection ()
+  (when (use-region-p)
+    (let* ((start (region-beginning))
+           (end (region-end))
+           (start-line (line-number-at-pos start))
+           (end-line (line-number-at-pos end))
+           (start-column (save-excursion (goto-char start) (current-column)))
+           (end-column (save-excursion (goto-char end) (current-column))))
+      `((text . ,(buffer-substring-no-properties start end))
+        (start . ((line . ,start-line) (column . ,start-column)))
+        (end . ((line . ,end-line) (column . ,end-column)))))))
+
+(defun pi-emacs--buffer-info (buffer active-buffer)
+  (with-current-buffer buffer
+    (let ((file (buffer-file-name buffer)))
+      `((name . ,(buffer-name buffer))
+        (file . ,(when file (expand-file-name file)))
+        (mode . ,(symbol-name major-mode))
+        (modified . ,(if (buffer-modified-p) t :json-false))
+        (active . ,(if (eq buffer active-buffer) t :json-false))))))
+
+(defun pi-emacs--buffer-list (active-buffer)
+  (let* ((buffers (pi-emacs--candidate-buffers))
+         (filtered (cl-remove-if-not (lambda (buf)
+                                       (or (buffer-file-name buf)
+                                           (eq buf active-buffer)))
+                                     buffers)))
+    (mapcar (lambda (buf) (pi-emacs--buffer-info buf active-buffer)) filtered)))
+
+(defun pi-emacs-context ()
+  (let* ((active-window (selected-window))
+         (window-buffer (window-buffer active-window))
+         (active-buffer (or (pi-emacs--buffer-with-active-region) window-buffer)))
+    (with-current-buffer active-buffer
+      (let* ((cursor-pos (if (eq active-buffer window-buffer)
+                             (window-point active-window)
+                           (point)))
+             (cursor-line (line-number-at-pos cursor-pos))
+             (cursor-column (save-excursion (goto-char cursor-pos) (current-column)))
+             (selection (pi-emacs--selection))
+             (persp-name (pi-emacs--current-persp-name))
+             (project-root (pi-emacs--project-root))
+             (buffers (vconcat (pi-emacs--buffer-list active-buffer))))
+        (json-serialize
+         `((buffer . ,(pi-emacs--buffer-info active-buffer active-buffer))
+           (cursor . ((line . ,cursor-line) (column . ,cursor-column)))
+           (selection . ,selection)
+           (persp . ,(when persp-name `((name . ,persp-name))))
+           (project . ,(when project-root `((root . ,project-root))))
+           (buffers . ,buffers))
+         :false-object :json-false)))))
+
+(defun pi-emacs-context-to-file (path)
+  (with-temp-file (expand-file-name path)
+    (insert (pi-emacs-context))))
+
+(provide 'pi-emacs-context)

--- a/emacs/scripts/context.sh
+++ b/emacs/scripts/context.sh
@@ -1,0 +1,24 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+if ! command -v emacsclient >/dev/null 2>&1; then
+  echo "emacsclient not found in PATH." >&2
+  exit 1
+fi
+
+if ! emacsclient --quiet --eval "(emacs-version)" >/dev/null 2>&1; then
+  echo "Emacs server not running. Start it with 'M-x server-start' or 'emacs --daemon'." >&2
+  exit 1
+fi
+
+base_dir="$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)"
+tmp_dir="${TMPDIR:-/tmp}"
+tmp_file="$(mktemp "${tmp_dir%/}/pi-emacs-context.XXXXXX")"
+
+cleanup() {
+  rm -f "$tmp_file"
+}
+trap cleanup EXIT
+
+emacsclient --quiet --eval "(progn (load-file \"${base_dir}/scripts/context.el\") (pi-emacs-context-to-file \"${tmp_file}\"))" >/dev/null
+cat "$tmp_file"


### PR DESCRIPTION
## Summary
- add `emacs` skill to export selection/buffer/persp context via emacsclient
- include `context.sh` + `context.el` helper scripts
- document installation and usage in README

## Testing
- not run (docs/scripts only)

Closes #6
