### PR TITLE
feat(browser-tools): add --tab flag for targeting specific tabs

### DIFF
--- a/browser-tools/SKILL.md
+++ b/browser-tools/SKILL.md
@@ -30,31 +30,37 @@ Launch Chrome with remote debugging on `:9222`. Use `--profile` to preserve user
 ```bash
 {baseDir}/browser-nav.js https://example.com
 {baseDir}/browser-nav.js https://example.com --new
+{baseDir}/browser-nav.js https://example.com --tab ABC123
 ```
 
-Navigate to URLs. Use `--new` flag to open in a new tab instead of reusing current tab.
+Navigate to URLs. Use `--new` flag to open in a new tab instead of reusing current tab. When `--new` is used, the output includes a `tab:<targetId>` that can be passed to other commands via `--tab` to target that specific tab.
+
+Use `--tab <targetId>` to navigate a specific tab by its target ID.
 
 ## Evaluate JavaScript
 
 ```bash
 {baseDir}/browser-eval.js 'document.title'
 {baseDir}/browser-eval.js 'document.querySelectorAll("a").length'
+{baseDir}/browser-eval.js --tab ABC123 'document.title'
 ```
 
-Execute JavaScript in the active tab. Code runs in async context. Use this to extract data, inspect page state, or perform DOM operations programmatically.
+Execute JavaScript in the active tab (or a specific tab with `--tab`). Code runs in async context. Use this to extract data, inspect page state, or perform DOM operations programmatically.
 
 ## Screenshot
 
 ```bash
 {baseDir}/browser-screenshot.js
+{baseDir}/browser-screenshot.js --tab ABC123
 ```
 
-Capture current viewport and return temporary file path. Use this to visually inspect page state or verify UI changes.
+Capture current viewport (or a specific tab with `--tab`) and return temporary file path. Use this to visually inspect page state or verify UI changes.
 
 ## Pick Elements
 
 ```bash
 {baseDir}/browser-pick.js "Click the submit button"
+{baseDir}/browser-pick.js --tab ABC123 "Click the submit button"
 ```
 
 **IMPORTANT**: Use this tool when the user wants to select specific DOM elements on the page. This launches an interactive picker that lets the user click elements to select them. The user can select multiple elements (Cmd/Ctrl+Click) and press Enter when done. The tool returns CSS selectors for the selected elements.
@@ -68,14 +74,16 @@ Common use cases:
 
 ```bash
 {baseDir}/browser-cookies.js
+{baseDir}/browser-cookies.js --tab ABC123
 ```
 
-Display all cookies for the current tab including domain, path, httpOnly, and secure flags. Use this to debug authentication issues or inspect session state.
+Display all cookies for the current tab (or a specific tab with `--tab`) including domain, path, httpOnly, and secure flags. Use this to debug authentication issues or inspect session state.
 
 ## Extract Page Content
 
 ```bash
 {baseDir}/browser-content.js https://example.com
+{baseDir}/browser-content.js https://example.com --tab ABC123
 ```
 
 Navigate to a URL and extract readable content as markdown. Uses Mozilla Readability for article extraction and Turndown for HTML-to-markdown conversion. Works on pages with JavaScript content (waits for page to load).

--- a/browser-tools/browser-content.js
+++ b/browser-tools/browser-content.js
@@ -13,14 +13,17 @@ const timeoutId = setTimeout(() => {
 	process.exit(1);
 }, TIMEOUT).unref();
 
-const url = process.argv[2];
+const args = process.argv.slice(2);
+const tabIdx = args.indexOf("--tab");
+const tabId = tabIdx !== -1 ? args[tabIdx + 1] : null;
+const url = args.find((a, i) => !a.startsWith("--") && (tabIdx === -1 || i !== tabIdx + 1));
 
 if (!url) {
-	console.log("Usage: browser-content.js <url>");
+	console.log("Usage: browser-content.js <url> [--tab <targetId>]");
 	console.log("\nExtracts readable content from a URL as markdown.");
 	console.log("\nExamples:");
 	console.log("  browser-content.js https://example.com");
-	console.log("  browser-content.js https://en.wikipedia.org/wiki/Rust_(programming_language)");
+	console.log("  browser-content.js https://example.com --tab ABC123");
 	process.exit(1);
 }
 
@@ -36,7 +39,17 @@ const b = await Promise.race([
 	process.exit(1);
 });
 
-const p = (await b.pages()).at(-1);
+let p;
+if (tabId) {
+	const pages = await b.pages();
+	p = pages.find((pg) => pg.target()._targetId === tabId);
+	if (!p) {
+		console.error(`✗ No tab found with id: ${tabId}`);
+		process.exit(1);
+	}
+} else {
+	p = (await b.pages()).at(-1);
+}
 if (!p) {
 	console.error("✗ No active tab found");
 	process.exit(1);

--- a/browser-tools/browser-cookies.js
+++ b/browser-tools/browser-cookies.js
@@ -2,6 +2,10 @@
 
 import puppeteer from "puppeteer-core";
 
+const args = process.argv.slice(2);
+const tabIdx = args.indexOf("--tab");
+const tabId = tabIdx !== -1 ? args[tabIdx + 1] : null;
+
 const b = await Promise.race([
 	puppeteer.connect({
 		browserURL: "http://localhost:9222",
@@ -14,7 +18,17 @@ const b = await Promise.race([
 	process.exit(1);
 });
 
-const p = (await b.pages()).at(-1);
+let p;
+if (tabId) {
+	const pages = await b.pages();
+	p = pages.find((pg) => pg.target()._targetId === tabId);
+	if (!p) {
+		console.error(`✗ No tab found with id: ${tabId}`);
+		process.exit(1);
+	}
+} else {
+	p = (await b.pages()).at(-1);
+}
 
 if (!p) {
 	console.error("✗ No active tab found");

--- a/browser-tools/browser-eval.js
+++ b/browser-tools/browser-eval.js
@@ -2,12 +2,17 @@
 
 import puppeteer from "puppeteer-core";
 
-const code = process.argv.slice(2).join(" ");
+const args = process.argv.slice(2);
+const tabIdx = args.indexOf("--tab");
+const tabId = tabIdx !== -1 ? args[tabIdx + 1] : null;
+const code = args.filter((a, i) => a !== "--tab" && (tabIdx === -1 || i !== tabIdx + 1)).join(" ");
+
 if (!code) {
-	console.log("Usage: browser-eval.js 'code'");
+	console.log("Usage: browser-eval.js [--tab <targetId>] 'code'");
 	console.log("\nExamples:");
 	console.log('  browser-eval.js "document.title"');
 	console.log('  browser-eval.js "document.querySelectorAll(\'a\').length"');
+	console.log('  browser-eval.js --tab ABC123 "document.title"');
 	process.exit(1);
 }
 
@@ -23,7 +28,17 @@ const b = await Promise.race([
 	process.exit(1);
 });
 
-const p = (await b.pages()).at(-1);
+let p;
+if (tabId) {
+	const pages = await b.pages();
+	p = pages.find((pg) => pg.target()._targetId === tabId);
+	if (!p) {
+		console.error(`✗ No tab found with id: ${tabId}`);
+		process.exit(1);
+	}
+} else {
+	p = (await b.pages()).at(-1);
+}
 
 if (!p) {
 	console.error("✗ No active tab found");

--- a/browser-tools/browser-nav.js
+++ b/browser-tools/browser-nav.js
@@ -5,14 +5,17 @@ import puppeteer from "puppeteer-core";
 const args = process.argv.slice(2);
 const newTab = args.includes("--new");
 const reload = args.includes("--reload");
-const url = args.find(a => !a.startsWith("--"));
+const tabIdx = args.indexOf("--tab");
+const tabId = tabIdx !== -1 ? args[tabIdx + 1] : null;
+const url = args.find((a, i) => !a.startsWith("--") && (tabIdx === -1 || i !== tabIdx + 1));
 
 if (!url) {
-	console.log("Usage: browser-nav.js <url> [--new] [--reload]");
+	console.log("Usage: browser-nav.js <url> [--new] [--reload] [--tab <targetId>]");
 	console.log("\nExamples:");
-	console.log("  browser-nav.js https://example.com          # Navigate current tab");
-	console.log("  browser-nav.js https://example.com --new    # Open in new tab");
-	console.log("  browser-nav.js https://example.com --reload # Navigate and force reload");
+	console.log("  browser-nav.js https://example.com              # Navigate current tab");
+	console.log("  browser-nav.js https://example.com --new        # Open in new tab (prints tab:<targetId>)");
+	console.log("  browser-nav.js https://example.com --reload     # Navigate and force reload");
+	console.log("  browser-nav.js https://example.com --tab ABC123 # Navigate specific tab");
 	process.exit(1);
 }
 
@@ -31,14 +34,26 @@ const b = await Promise.race([
 if (newTab) {
 	const p = await b.newPage();
 	await p.goto(url, { waitUntil: "domcontentloaded" });
-	console.log("✓ Opened:", url);
+	console.log(`✓ Opened: ${url} tab:${p.target()._targetId}`);
+} else if (tabId) {
+	const pages = await b.pages();
+	const p = pages.find((pg) => pg.target()._targetId === tabId);
+	if (!p) {
+		console.error(`✗ No tab found with id: ${tabId}`);
+		process.exit(1);
+	}
+	await p.goto(url, { waitUntil: "domcontentloaded" });
+	if (reload) {
+		await p.reload({ waitUntil: "domcontentloaded" });
+	}
+	console.log(`✓ Navigated to: ${url}`);
 } else {
 	const p = (await b.pages()).at(-1);
 	await p.goto(url, { waitUntil: "domcontentloaded" });
 	if (reload) {
 		await p.reload({ waitUntil: "domcontentloaded" });
 	}
-	console.log("✓ Navigated to:", url);
+	console.log(`✓ Navigated to: ${url}`);
 }
 
 await b.disconnect();

--- a/browser-tools/browser-pick.js
+++ b/browser-tools/browser-pick.js
@@ -2,11 +2,16 @@
 
 import puppeteer from "puppeteer-core";
 
-const message = process.argv.slice(2).join(" ");
+const args = process.argv.slice(2);
+const tabIdx = args.indexOf("--tab");
+const tabId = tabIdx !== -1 ? args[tabIdx + 1] : null;
+const message = args.filter((a, i) => a !== "--tab" && (tabIdx === -1 || i !== tabIdx + 1)).join(" ");
+
 if (!message) {
-	console.log("Usage: browser-pick.js 'message'");
+	console.log("Usage: browser-pick.js [--tab <targetId>] 'message'");
 	console.log("\nExample:");
 	console.log('  browser-pick.js "Click the submit button"');
+	console.log('  browser-pick.js --tab ABC123 "Click the submit button"');
 	process.exit(1);
 }
 
@@ -22,7 +27,17 @@ const b = await Promise.race([
 	process.exit(1);
 });
 
-const p = (await b.pages()).at(-1);
+let p;
+if (tabId) {
+	const pages = await b.pages();
+	p = pages.find((pg) => pg.target()._targetId === tabId);
+	if (!p) {
+		console.error(`✗ No tab found with id: ${tabId}`);
+		process.exit(1);
+	}
+} else {
+	p = (await b.pages()).at(-1);
+}
 
 if (!p) {
 	console.error("✗ No active tab found");

--- a/browser-tools/browser-screenshot.js
+++ b/browser-tools/browser-screenshot.js
@@ -4,6 +4,10 @@ import { tmpdir } from "node:os";
 import { join } from "node:path";
 import puppeteer from "puppeteer-core";
 
+const args = process.argv.slice(2);
+const tabIdx = args.indexOf("--tab");
+const tabId = tabIdx !== -1 ? args[tabIdx + 1] : null;
+
 const b = await Promise.race([
 	puppeteer.connect({
 		browserURL: "http://localhost:9222",
@@ -16,7 +20,17 @@ const b = await Promise.race([
 	process.exit(1);
 });
 
-const p = (await b.pages()).at(-1);
+let p;
+if (tabId) {
+	const pages = await b.pages();
+	p = pages.find((pg) => pg.target()._targetId === tabId);
+	if (!p) {
+		console.error(`✗ No tab found with id: ${tabId}`);
+		process.exit(1);
+	}
+} else {
+	p = (await b.pages()).at(-1);
+}
 
 if (!p) {
 	console.error("✗ No active tab found");

--- a/browser-tools/package-lock.json
+++ b/browser-tools/package-lock.json
@@ -177,7 +177,6 @@
 				}
 			],
 			"license": "MIT",
-			"peer": true,
 			"engines": {
 				"node": ">=18"
 			},
@@ -219,7 +218,6 @@
 				}
 			],
 			"license": "MIT",
-			"peer": true,
 			"engines": {
 				"node": ">=18"
 			}
@@ -831,8 +829,7 @@
 			"version": "0.0.1367902",
 			"resolved": "https://registry.npmjs.org/devtools-protocol/-/devtools-protocol-0.0.1367902.tgz",
 			"integrity": "sha512-XxtPuC3PGakY6PD7dG66/o8KwJ/LkH2/EKe19Dcw58w53dv4/vSQEkn/SzuyhHE2q4zPgCkxQBxus3VV4ql+Pg==",
-			"license": "BSD-3-Clause",
-			"peer": true
+			"license": "BSD-3-Clause"
 		},
 		"node_modules/dom-serializer": {
 			"version": "2.0.0",
@@ -1800,7 +1797,6 @@
 			"resolved": "https://registry.npmjs.org/puppeteer-core/-/puppeteer-core-23.11.1.tgz",
 			"integrity": "sha512-3HZ2/7hdDKZvZQ7dhhITOUg4/wOrDRjyK2ZBllRB0ZCOi9u0cwq1ACHDjBB+nX+7+kltHjQvBRdeY7+W0T+7Gg==",
 			"license": "Apache-2.0",
-			"peer": true,
 			"dependencies": {
 				"@puppeteer/browsers": "2.6.1",
 				"chromium-bidi": "0.11.0",
@@ -1818,7 +1814,6 @@
 			"resolved": "https://registry.npmjs.org/puppeteer-extra/-/puppeteer-extra-3.3.6.tgz",
 			"integrity": "sha512-rsLBE/6mMxAjlLd06LuGacrukP2bqbzKCLzV1vrhHFavqQE/taQ2UXv3H5P0Ls7nsrASa+6x3bDbXHpqMwq+7A==",
 			"license": "MIT",
-			"peer": true,
 			"dependencies": {
 				"@types/debug": "^4.1.0",
 				"debug": "^4.1.1",
@@ -1988,8 +1983,7 @@
 			"version": "0.0.1521046",
 			"resolved": "https://registry.npmjs.org/devtools-protocol/-/devtools-protocol-0.0.1521046.tgz",
 			"integrity": "sha512-vhE6eymDQSKWUXwwA37NtTTVEzjtGVfDr3pRbsWEQ5onH/Snp2c+2xZHWJJawG/0hCCJLRGt4xVtEVUVILol4w==",
-			"license": "BSD-3-Clause",
-			"peer": true
+			"license": "BSD-3-Clause"
 		},
 		"node_modules/puppeteer/node_modules/puppeteer-core": {
 			"version": "24.31.0",


### PR DESCRIPTION
## Summary

Adds `--tab <targetId>` option to all tab-interacting browser-tools commands, enabling parallel multi-tab workflows.

## Problem

All browser-tools commands target the last active tab via `(await b.pages()).at(-1)`. This makes it impossible to work with multiple tabs concurrently — e.g., when sub-agents each open their own tab, they can't reliably screenshot or interact with their specific tab.

## Changes

### `browser-nav.js`
- `--new` flag now outputs the tab's target ID: `✓ Opened: <url> tab:<targetId>`
- New `--tab <targetId>` option to navigate a specific tab

### `browser-screenshot.js`, `browser-eval.js`, `browser-content.js`, `browser-cookies.js`, `browser-pick.js`
- New `--tab <targetId>` option to target a specific tab
- Without `--tab`, behavior is unchanged (targets last active tab)

### `SKILL.md`
- Documents the new `--tab` option for all commands

## Example

```bash
# Open two tabs, get their IDs
TAB1=$(browser-nav.js https://example.com --new | grep -o 'tab:.*' | cut -d: -f2)
TAB2=$(browser-nav.js https://httpbin.org --new | grep -o 'tab:.*' | cut -d: -f2)

# Screenshot each tab independently
browser-screenshot.js --tab $TAB1   # captures example.com
browser-screenshot.js --tab $TAB2   # captures httpbin.org
browser-screenshot.js               # captures last active tab (unchanged)
```

## Backward Compatibility

Fully backward compatible. All commands default to the last active tab when `--tab` is not provided.