### PR TITLE
fix(browser-tools): page selection and disconnect hang bugs

### DIFF
--- a/browser-tools/browser-content.js
+++ b/browser-tools/browser-content.js
@@ -36,24 +36,28 @@ const b = await Promise.race([
 	process.exit(1);
 });
 
-const p = (await b.pages()).at(-1);
-if (!p) {
+const pages = await b.pages();
+const types = await Promise.all(pages.map(p => p.target().type()));
+const idx = types.findIndex(t => t === 'page');
+const page = pages[idx >= 0 ? idx : 0];
+
+if (!page) {
 	console.error("✗ No active tab found");
 	process.exit(1);
 }
 
 await Promise.race([
-	p.goto(url, { waitUntil: "networkidle2" }),
+	page.goto(url, { waitUntil: "networkidle2" }),
 	new Promise((r) => setTimeout(r, 10000)),
 ]).catch(() => {});
 
 // Get HTML via CDP (works even with TrustedScriptURL restrictions)
-const client = await p.createCDPSession();
+const client = await page.createCDPSession();
 const { root } = await client.send("DOM.getDocument", { depth: -1, pierce: true });
 const { outerHTML } = await client.send("DOM.getOuterHTML", { nodeId: root.nodeId });
 await client.detach();
 
-const finalUrl = p.url();
+const finalUrl = page.url();
 
 // Extract with Readability
 const doc = new JSDOM(outerHTML, { url: finalUrl });

--- a/browser-tools/browser-cookies.js
+++ b/browser-tools/browser-cookies.js
@@ -14,14 +14,17 @@ const b = await Promise.race([
 	process.exit(1);
 });
 
-const p = (await b.pages()).at(-1);
+const pages = await b.pages();
+const types = await Promise.all(pages.map(p => p.target().type()));
+const idx = types.findIndex(t => t === 'page');
+const page = pages[idx >= 0 ? idx : 0];
 
-if (!p) {
+if (!page) {
 	console.error("✗ No active tab found");
 	process.exit(1);
 }
 
-const cookies = await p.cookies();
+const cookies = await page.cookies();
 
 for (const cookie of cookies) {
 	console.log(`${cookie.name}: ${cookie.value}`);
@@ -32,4 +35,4 @@ for (const cookie of cookies) {
 	console.log("");
 }
 
-await b.disconnect();
+process.exit(0);

--- a/browser-tools/browser-eval.js
+++ b/browser-tools/browser-eval.js
@@ -23,14 +23,17 @@ const b = await Promise.race([
 	process.exit(1);
 });
 
-const p = (await b.pages()).at(-1);
+const pages = await b.pages();
+const types = await Promise.all(pages.map(p => p.target().type()));
+const idx = types.findIndex(t => t === 'page');
+const page = pages[idx >= 0 ? idx : 0];
 
-if (!p) {
+if (!page) {
 	console.error("✗ No active tab found");
 	process.exit(1);
 }
 
-const result = await p.evaluate((c) => {
+const result = await page.evaluate((c) => {
 	const AsyncFunction = (async () => {}).constructor;
 	return new AsyncFunction(`return (${c})`)();
 }, code);
@@ -50,4 +53,4 @@ if (Array.isArray(result)) {
 	console.log(result);
 }
 
-await b.disconnect();
+process.exit(0);

--- a/browser-tools/browser-nav.js
+++ b/browser-tools/browser-nav.js
@@ -32,8 +32,12 @@ if (newTab) {
 	const p = await b.newPage();
 	await p.goto(url, { waitUntil: "domcontentloaded" });
 	console.log("✓ Opened:", url);
+	process.exit(0);
 } else {
-	const p = (await b.pages()).at(-1);
+	const pages = await b.pages();
+	const types = await Promise.all(pages.map(p => p.target().type()));
+	const idx = types.findIndex(t => t === 'page');
+	const p = pages[idx >= 0 ? idx : 0];
 	await p.goto(url, { waitUntil: "domcontentloaded" });
 	if (reload) {
 		await p.reload({ waitUntil: "domcontentloaded" });
@@ -41,4 +45,4 @@ if (newTab) {
 	console.log("✓ Navigated to:", url);
 }
 
-await b.disconnect();
+process.exit(0);

--- a/browser-tools/browser-pick.js
+++ b/browser-tools/browser-pick.js
@@ -22,15 +22,18 @@ const b = await Promise.race([
 	process.exit(1);
 });
 
-const p = (await b.pages()).at(-1);
+const pages = await b.pages();
+const types = await Promise.all(pages.map(p => p.target().type()));
+const idx = types.findIndex(t => t === 'page');
+const page = pages[idx >= 0 ? idx : 0];
 
-if (!p) {
+if (!page) {
 	console.error("✗ No active tab found");
 	process.exit(1);
 }
 
 // Inject pick() helper into current page
-await p.evaluate(() => {
+await page.evaluate(() => {
 	if (!window.pick) {
 		window.pick = async (message) => {
 			if (!message) {
@@ -142,7 +145,7 @@ await p.evaluate(() => {
 	}
 });
 
-const result = await p.evaluate((msg) => window.pick(msg), message);
+const result = await page.evaluate((msg) => window.pick(msg), message);
 
 if (Array.isArray(result)) {
 	for (let i = 0; i < result.length; i++) {
@@ -159,4 +162,4 @@ if (Array.isArray(result)) {
 	console.log(result);
 }
 
-await b.disconnect();
+process.exit(0);

--- a/browser-tools/browser-screenshot.js
+++ b/browser-tools/browser-screenshot.js
@@ -16,9 +16,12 @@ const b = await Promise.race([
 	process.exit(1);
 });
 
-const p = (await b.pages()).at(-1);
+const pages = await b.pages();
+const types = await Promise.all(pages.map(p => p.target().type()));
+const idx = types.findIndex(t => t === 'page');
+const page = pages[idx >= 0 ? idx : 0];
 
-if (!p) {
+if (!page) {
 	console.error("✗ No active tab found");
 	process.exit(1);
 }
@@ -27,8 +30,8 @@ const timestamp = new Date().toISOString().replace(/[:.]/g, "-");
 const filename = `screenshot-${timestamp}.png`;
 const filepath = join(tmpdir(), filename);
 
-await p.screenshot({ path: filepath });
+await page.screenshot({ path: filepath });
 
 console.log(filepath);
 
-await b.disconnect();
+process.exit(0);


### PR DESCRIPTION
## Summary

This PR fixes two bugs across all 6 browser CDP scripts that break common usage scenarios.

## Bugs Fixed

### 1. `.at(-1)` page selection grabs service workers, crashes scripts

In puppeteer-core v23+, `browser.pages()` returns **all CDP targets** including extension service workers and background pages. The original code used `.at(-1)` to pick the last page, which typically selects a service worker or background page when Chrome extensions are installed.

**Before:** Crashes with `TypeError: Cannot read properties of undefined` in screenshot/eval/cookies when any extension is loaded.

**Fix:** Filter targets by `page.target().type() === 'page'`, fall back to `pages[0]`.

### 2. `b.disconnect()` hangs indefinitely

Calling `await b.disconnect()` after connecting to an already-running Chrome instance via `puppeteer-core.connect()` never resolves — the promise hangs forever, making every script invocation require `SIGKILL`.

**Before:** Every script hangs after completing its task. Can't chain commands (e.g., nav → screenshot → eval) in automation.

**Fix:** Replace `await b.disconnect()` with `process.exit(0)`.

## Files Changed

| File | Change |
|------|--------|
| browser-screenshot.js | Fix page selection + remove disconnect() |
| browser-eval.js | Fix page selection + remove disconnect() |
| browser-nav.js | Fix page selection + remove disconnect() |
| browser-content.js | Fix page selection (already had process.exit) |
| browser-cookies.js | Fix page selection + remove disconnect() |
| browser-pick.js | Fix page selection + remove disconnect() |

## Verified Working

All 6 tools tested end-to-end against a live Chrome instance with extensions loaded:
- Navigate ✅
- Screenshot ✅
- JS Eval ✅
- Cookies ✅
- Pick helper injection ✅
- Content extraction ✅