### PR TITLE
feat: add quant-scanner + a-share-scanner — dual-market quantitative stock screening

### DIFF
--- a/a-share-scanner/SKILL.md
+++ b/a-share-scanner/SKILL.md
@@ -1,0 +1,74 @@
+---
+name: a-share-scanner
+description: A股量化选股扫描器，模型驱动自适应因子评分。通过 Tushare 扫描全 A 股 5000+ 只股票，检测市场环境（波动率、动量、资金面、板块轮动），动态调整因子权重，输出选股榜/异动榜/行业分布的 HTML 报告。适用于 A 股选股、量化筛选、因子分析、市场环境诊断、板块轮动、动量策略、价值投资筛选。Use for Chinese A-share stock screening, quantitative stock picking, sector rotation, market regime detection.
+---
+
+# A股量化选股扫描器 v1.0
+
+模型驱动的全 A 股量化选股工具。扫描 5000+ 只 A 股，检测市场环境，自适应调整 6 因子权重，输出选股/异动排名 + HTML 报告。
+
+## 配置
+
+**必需：** 一个免费的 Tushare Pro token。
+
+1. 访问 [https://tushare.pro](https://tushare.pro) 注册（免费）
+2. 在个人主页获取 API Token
+3. 设置环境变量：
+
+```bash
+export TUSHARE_TOKEN="your_token_here"
+```
+
+或直接传参：
+
+```bash
+python3 {baseDir}/scripts/a_share_scan.py --token YOUR_TOKEN
+```
+
+**依赖安装：**
+
+```bash
+pip install tushare pandas
+```
+
+## 快速命令
+
+```bash
+# 全A扫描
+python3 {baseDir}/scripts/a_share_scan.py
+
+# 快速 Top 10
+python3 {baseDir}/scripts/a_share_scan.py --top 10
+
+# 指定股票
+python3 {baseDir}/scripts/a_share_scan.py --codes 000001,600519,300750
+
+# JSON 输出
+python3 {baseDir}/scripts/a_share_scan.py --format json
+```
+
+## 6 因子自适应评分
+
+| 因子 | 基础权重 | 趋势市 | 震荡市 | 高波动 |
+| --- | ---: | --- | --- | --- |
+| **动量** | 25% | x1.3 | x0.7 | — |
+| **量能** | 20% | — | — | — |
+| **估值** | 15% | x0.8 | x1.3 | — |
+| **成长** | 20% | — | — | x1.2 |
+| **量价确认** | 10% | — | — | — |
+| **风险调整** | 10% | — | — | x1.4 |
+
+## 市场环境检测
+
+- **波动率** — 全市场涨跌幅标准差
+- **动量** — 上涨比例 + 平均涨幅
+- **资金面** — 涨停/跌停数 + 涨跌比
+
+## 数据
+
+全 A 股（上交所 + 深交所 + 北交所），Tushare Pro 免费接口。
+
+## 限制
+
+- 全A扫描约 10-30 秒
+- 不构成投资建议

--- a/a-share-scanner/scripts/a_share_scan.py
+++ b/a-share-scanner/scripts/a_share_scan.py
@@ -1,0 +1,620 @@
+# /// script
+# requires-python = ">=3.9"
+# dependencies = ["tushare", "pandas"]
+# ///
+"""A-Share Quant Scanner — Tushare-powered, model-driven adaptive factor scoring.
+
+Scans full A-share market (5000+ stocks), detects market regime,
+scores on 6 adaptive factors, outputs HTML + JSON report.
+
+Usage:
+    python3 a_share_scan.py                           # Full scan
+    python3 a_share_scan.py --top 10                   # Quick top 10
+    python3 a_share_scan.py --codes 000001,600519      # Specific codes
+    python3 a_share_scan.py --format json               # JSON only
+    python3 a_share_scan.py --token YOUR_TUSHARE_TOKEN  # Pass token
+"""
+
+from __future__ import annotations
+
+import argparse
+import json
+import math
+import os
+import statistics
+import sys
+from dataclasses import dataclass, field, asdict
+from datetime import datetime, timedelta
+from pathlib import Path
+from typing import Dict, List, Optional
+
+try:
+    import tushare as ts
+    import pandas as pd
+except ImportError:
+    print("Error: 需要安装 tushare 和 pandas", file=sys.stderr)
+    print("  pip install tushare pandas", file=sys.stderr)
+    print("  或: uv run a_share_scan.py (自动安装)", file=sys.stderr)
+    sys.exit(1)
+
+
+# ── Helpers ──────────────────────────────────────────────────────
+
+def sf(val, default=0.0) -> float:
+    try:
+        v = float(val) if val is not None else default
+        return default if math.isnan(v) or math.isinf(v) else v
+    except (TypeError, ValueError):
+        return default
+
+
+def pct(cur: float, prev: float) -> float:
+    return (cur - prev) / prev * 100 if prev else 0.0
+
+
+def clamp(v: float, lo: float, hi: float) -> float:
+    return max(lo, min(hi, v))
+
+
+def to_westock_code(ts_code: str) -> str:
+    digits, market = ts_code.split(".")
+    return f"{market.lower()}{digits}"
+
+
+# ── Data ─────────────────────────────────────────────────────────
+
+@dataclass
+class StockRow:
+    ts_code: str
+    code: str
+    name: str
+    industry: str
+    market: str
+    close: float
+    pct_chg: float
+    return_5d: float
+    return_20d: float
+    volume_ratio: float
+    turnover_rate: float
+    amount: float
+    total_mv: float
+    pe_ttm: float
+    pb: float
+    selection_score: float
+    anomaly_score: float
+    f_momentum: float
+    f_volume: float
+    f_valuation: float
+    f_growth: float
+    f_analyst: float
+    f_risk: float
+    tags: List[str] = field(default_factory=list)
+    risk_notes: List[str] = field(default_factory=list)
+
+
+@dataclass
+class Regime:
+    volatility_level: str
+    momentum_regime: str
+    money_flow_bias: str
+    avg_pct_chg: float
+    std_pct_chg: float
+    pct_positive: float
+    limit_up_count: int
+    limit_down_count: int
+    up_down_ratio: float
+    avg_turnover: float
+    avg_volume_ratio: float
+
+
+# ── Scanner ──────────────────────────────────────────────────────
+
+class AShareScanner:
+    def __init__(self, token: str):
+        ts.set_token(token)
+        self.pro = ts.pro_api(token)
+        self.stocks: List[StockRow] = []
+        self.regime: Optional[Regime] = None
+        self.trade_date: str = ""
+        self.universe_count: int = 0
+        self.filtered_count: int = 0
+
+    def scan(self, *, top_n: int = 100, min_amount: float = 100000.0,
+             specific_codes: List[str] | None = None) -> None:
+        print("获取交易日历...", file=sys.stderr)
+        trade_dates = self._trade_dates(lookback=90)
+        self.trade_date = trade_dates[-1]
+        print(f"最新交易日: {self.trade_date}", file=sys.stderr)
+
+        print("获取全A日线快照...", file=sys.stderr)
+        latest = self.pro.daily(trade_date=self.trade_date)
+        if latest is None or latest.empty:
+            raise RuntimeError(f"未获取到 {self.trade_date} 的日线数据")
+        self.universe_count = len(latest)
+
+        # Reference dates
+        idx = trade_dates.index(self.trade_date)
+        date_5d = trade_dates[max(0, idx - 5)]
+        date_20d = trade_dates[max(0, idx - 20)]
+
+        print(f"获取参照日行情 (5D={date_5d}, 20D={date_20d})...", file=sys.stderr)
+        daily_5d = self.pro.daily(trade_date=date_5d)
+        daily_20d = self.pro.daily(trade_date=date_20d)
+
+        print("获取股票基本信息...", file=sys.stderr)
+        basics = self.pro.stock_basic(exchange="", list_status="L",
+                                       fields="ts_code,name,industry,market,list_date")
+
+        print("获取每日指标 (量比/PE/PB/市值)...", file=sys.stderr)
+        daily_basic = self._safe_daily_basic(self.trade_date)
+
+        # Merge
+        df = latest.merge(daily_5d[["ts_code", "close"]].rename(columns={"close": "close_5d"}),
+                          on="ts_code", how="left")
+        df = df.merge(daily_20d[["ts_code", "close"]].rename(columns={"close": "close_20d"}),
+                      on="ts_code", how="left")
+        df = df.merge(basics, on="ts_code", how="left")
+        if daily_basic is not None:
+            df = df.merge(daily_basic, on="ts_code", how="left")
+
+        print("评分中...", file=sys.stderr)
+        rows = []
+        for item in df.to_dict("records"):
+            name = str(item.get("name") or "")
+            if not name or "ST" in name.upper():
+                continue
+            close = sf(item.get("close"))
+            amount = sf(item.get("amount"))
+            if close <= 2 or amount < min_amount:
+                continue
+
+            ts_code = item["ts_code"]
+            code = to_westock_code(ts_code)
+
+            if specific_codes and code not in specific_codes and ts_code not in specific_codes:
+                continue
+
+            pct_chg = sf(item.get("pct_chg"))
+            return_5d = pct(close, sf(item.get("close_5d")))
+            return_20d = pct(close, sf(item.get("close_20d")))
+            volume_ratio = sf(item.get("volume_ratio"))
+            turnover = sf(item.get("turnover_rate"))
+            total_mv = sf(item.get("total_mv"))
+            pe = sf(item.get("pe_ttm"))
+            pb = sf(item.get("pb"))
+
+            rows.append({
+                "ts_code": ts_code, "code": code, "name": name,
+                "industry": str(item.get("industry") or ""),
+                "market": str(item.get("market") or ""),
+                "close": close, "pct_chg": pct_chg,
+                "return_5d": return_5d, "return_20d": return_20d,
+                "volume_ratio": volume_ratio, "turnover_rate": turnover,
+                "amount": amount, "total_mv": total_mv,
+                "pe_ttm": pe, "pb": pb,
+            })
+
+        self.filtered_count = len(rows)
+        print(f"过滤后: {self.filtered_count} 只 (原始 {self.universe_count})", file=sys.stderr)
+
+        # Detect regime
+        self.regime = self._detect_regime(rows)
+
+        # Score
+        self.stocks = self._score_all(rows, top_n)
+
+    def _trade_dates(self, lookback: int) -> List[str]:
+        end = datetime.now().strftime("%Y%m%d")
+        start = (datetime.now() - timedelta(days=lookback * 2)).strftime("%Y%m%d")
+        cal = self.pro.trade_cal(exchange="SSE", start_date=start, end_date=end,
+                                  is_open="1", fields="cal_date")
+        return sorted(str(v) for v in cal["cal_date"].tolist())
+
+    def _safe_daily_basic(self, trade_date: str):
+        try:
+            fields = "ts_code,trade_date,turnover_rate,volume_ratio,total_mv,circ_mv,pe_ttm,pb"
+            db = self.pro.daily_basic(trade_date=trade_date, fields=fields)
+            if db is None or db.empty:
+                return None
+            return db.drop(columns=["trade_date"], errors="ignore")
+        except Exception:
+            return None
+
+    def _detect_regime(self, rows: List[dict]) -> Regime:
+        chgs = [r["pct_chg"] for r in rows]
+        vrs = [r["volume_ratio"] for r in rows if r["volume_ratio"] > 0]
+        tos = [r["turnover_rate"] for r in rows if r["turnover_rate"] > 0]
+
+        avg_chg = statistics.mean(chgs) if chgs else 0
+        std_chg = statistics.stdev(chgs) if len(chgs) > 1 else 2
+        pct_pos = sum(1 for c in chgs if c > 0) / len(chgs) * 100 if chgs else 50
+        limit_up = sum(1 for c in chgs if c >= 9.5)
+        limit_down = sum(1 for c in chgs if c <= -9.5)
+        ratio = sum(1 for c in chgs if c > 0) / max(sum(1 for c in chgs if c < 0), 1)
+        avg_vr = statistics.mean(vrs) if vrs else 1
+        avg_to = statistics.mean(tos) if tos else 3
+
+        vol = "high" if std_chg > 3.5 else ("low" if std_chg < 1.5 else "medium")
+        mom = "trending" if avg_chg > 1 and pct_pos > 60 else (
+              "declining" if avg_chg < -1 and pct_pos < 40 else "neutral")
+        mf = "bullish" if ratio > 1.5 and limit_up > limit_down * 2 else (
+             "bearish" if ratio < 0.7 and limit_down > limit_up else "neutral")
+
+        return Regime(
+            volatility_level=vol, momentum_regime=mom, money_flow_bias=mf,
+            avg_pct_chg=round(avg_chg, 3), std_pct_chg=round(std_chg, 3),
+            pct_positive=round(pct_pos, 1),
+            limit_up_count=limit_up, limit_down_count=limit_down,
+            up_down_ratio=round(ratio, 2),
+            avg_turnover=round(avg_to, 2), avg_volume_ratio=round(avg_vr, 2),
+        )
+
+    def _score_all(self, rows: List[dict], top_n: int) -> List[StockRow]:
+        rg = self.regime
+        trending = rg.momentum_regime == "trending"
+        declining = rg.momentum_regime == "declining"
+        hvol = rg.volatility_level == "high"
+
+        mb = 1.3 if trending else (0.7 if declining else 1.0)
+        vb = 1.3 if declining else (0.8 if trending else 1.0)
+        vp = 1.4 if hvol else 1.0
+        qb = 1.2 if hvol else 1.0
+
+        # Normalize amount for liquidity score
+        max_amt = max((r["amount"] for r in rows), default=1) or 1
+
+        scored = []
+        for r in rows:
+            # F1: Momentum
+            fm = (
+                clamp(r["pct_chg"], -10, 10) * 1.5 * mb
+                + clamp(r["return_5d"], -30, 60) * 0.8 * mb
+                + clamp(r["return_20d"], -40, 120) * 0.25
+            )
+
+            # F2: Volume/Liquidity
+            fv = (
+                clamp(r["volume_ratio"], 0, 5) * 6
+                + clamp(r["turnover_rate"], 0, 20) * 0.5
+                + math.log1p(r["amount"]) / math.log1p(max_amt) * 10
+            )
+
+            # F3: Valuation
+            pe = r["pe_ttm"]
+            pe_score = max(10 - abs(pe - 30) / 5, 0) if 0 < pe < 100 else 0
+            pb_score = max(8 - abs(r["pb"] - 3) / 1.5, 0) if 0 < r["pb"] < 20 else 0
+            fval = (pe_score + pb_score) * vb
+
+            # F4: Growth proxy (from price momentum as proxy, since we don't have financials in daily)
+            fg = (
+                clamp(r["return_5d"], 0, 50) * 0.4
+                + clamp(r["return_20d"], 0, 100) * 0.2
+            ) * qb
+
+            # F5: Analyst proxy (volume + price confirmation)
+            fa = 0.0
+            if r["pct_chg"] > 0 and 1.2 <= r["volume_ratio"] <= 4.5:
+                fa = 8  # 量价配合
+            if r["pct_chg"] > 0 and r["return_5d"] > 0 and r["return_20d"] > 0:
+                fa += 5  # 多周期共振
+
+            # F6: Risk
+            fr = (
+                -max(r["pct_chg"] - 9.5, 0) * 4  # 涨停追高风险
+                - max(r["return_20d"] - 80, 0) * 0.3  # 连续暴涨风险
+                - max(r["volume_ratio"] - 5, 0) * 3 * vp  # 异常放量
+                - max(r["turnover_rate"] - 20, 0) * 0.5 * vp  # 换手过高
+            )
+
+            score = fm * 0.25 + fv * 0.20 + fval * 0.15 + fg * 0.20 + fa * 0.10 + fr * 0.10
+            anom = (
+                abs(r["pct_chg"]) * 2.0
+                + clamp(r["volume_ratio"], 0, 6) * 8
+                + clamp(r["turnover_rate"], 0, 25) * 0.7
+                + abs(clamp(r["return_5d"], -50, 80)) * 0.35
+            )
+
+            tags = self._tags(r)
+            risks = self._risks(r)
+
+            scored.append(StockRow(
+                ts_code=r["ts_code"], code=r["code"], name=r["name"],
+                industry=r["industry"], market=r["market"],
+                close=round(r["close"], 2), pct_chg=round(r["pct_chg"], 2),
+                return_5d=round(r["return_5d"], 2), return_20d=round(r["return_20d"], 2),
+                volume_ratio=round(r["volume_ratio"], 2),
+                turnover_rate=round(r["turnover_rate"], 2),
+                amount=round(r["amount"], 0),
+                total_mv=round(r["total_mv"], 0),
+                pe_ttm=round(pe, 1), pb=round(r["pb"], 2),
+                selection_score=round(score, 2), anomaly_score=round(anom, 2),
+                f_momentum=round(fm, 2), f_volume=round(fv, 2),
+                f_valuation=round(fval, 2), f_growth=round(fg, 2),
+                f_analyst=round(fa, 2), f_risk=round(fr, 2),
+                tags=tags, risk_notes=risks,
+            ))
+
+        return sorted(scored, key=lambda x: x.selection_score, reverse=True)
+
+    @staticmethod
+    def _tags(r: dict) -> List[str]:
+        t = []
+        if r["pct_chg"] >= 9.5: t.append("接近涨停")
+        elif r["pct_chg"] <= -8: t.append("大跌异动")
+        elif abs(r["pct_chg"]) >= 5: t.append("价格异动")
+        if r["volume_ratio"] >= 2: t.append("显著放量")
+        elif r["volume_ratio"] >= 1.3: t.append("温和放量")
+        if r["turnover_rate"] >= 10: t.append("高换手")
+        if r["return_5d"] >= 20: t.append("5日强势")
+        if r["return_20d"] >= 40: t.append("20日强势")
+        if r["amount"] >= 1000000: t.append("高成交额")
+        if 0 < r["pe_ttm"] < 15: t.append("低估值")
+        if r["pct_chg"] > 0 and 1.2 <= r["volume_ratio"] <= 4.5: t.append("量价配合")
+        return t or ["普通波动"]
+
+    @staticmethod
+    def _risks(r: dict) -> List[str]:
+        n = []
+        if r["pct_chg"] >= 9.5: n.append("接近涨停追高风险")
+        if r["return_20d"] > 60: n.append("短期涨幅过大")
+        if r["volume_ratio"] > 5: n.append("异常放量")
+        if r["turnover_rate"] > 20: n.append("换手过高")
+        if r["pe_ttm"] > 100: n.append("估值偏高")
+        return n or ["风险均衡"]
+
+
+# ── HTML Report ──────────────────────────────────────────────────
+
+def bdg(level: str, text: str) -> str:
+    c = {"high": "#dc2626", "low": "#16a34a", "medium": "#d97706",
+         "trending": "#dc2626", "declining": "#16a34a", "neutral": "#6b7280",
+         "bullish": "#dc2626", "bearish": "#16a34a"}.get(level, "#6b7280")
+    return f'<span style="display:inline-block;padding:2px 10px;border-radius:12px;background:{c}22;color:{c};font-weight:600;font-size:.85rem">{text}</span>'
+
+
+def fmt_mv(v: float) -> str:
+    if v >= 10000: return f"{v / 10000:.0f}亿"
+    return f"{v:.0f}万"
+
+
+def fmt_amt(v: float) -> str:
+    if v >= 1000000: return f"{v / 1000000:.1f}百万"
+    if v >= 10000: return f"{v / 10000:.1f}万"
+    return f"{v:.0f}"
+
+
+def html_report(sc: AShareScanner) -> str:
+    rg = sc.regime
+    scored = sc.stocks
+    now = datetime.now().strftime("%Y-%m-%d %H:%M")
+    sels = [s for s in scored if s.selection_score > 0][:30]
+    anoms = sorted(scored, key=lambda x: x.anomaly_score, reverse=True)[:20]
+    port = scored[:5]
+
+    ic: Dict[str, int] = {}
+    for s in scored[:50]:
+        ic[s.industry] = ic.get(s.industry, 0) + 1
+    ti = sorted(ic.items(), key=lambda x: x[1], reverse=True)[:15]
+
+    def trs(items, fn):
+        return "\n".join(f"<tr>{fn(i, s)}</tr>" for i, s in enumerate(items, 1))
+
+    def sel_fn(i, s):
+        tg = " ".join(f'<span class="tg">{t}</span>' for t in s.tags)
+        cc = "up" if s.pct_chg > 0 else ("dn" if s.pct_chg < 0 else "")
+        return (f"<td>{i}</td><td class='tk'>{s.code}</td><td>{s.name}</td><td>{s.industry}</td>"
+                f"<td class='n'>{s.close:.2f}</td>"
+                f"<td class='n {cc}'>{s.pct_chg:+.2f}%</td>"
+                f"<td class='n {'up' if s.return_5d>0 else 'dn'}'>{s.return_5d:+.1f}%</td>"
+                f"<td class='n {'up' if s.return_20d>0 else 'dn'}'>{s.return_20d:+.1f}%</td>"
+                f"<td class='n'>{s.volume_ratio:.2f}</td>"
+                f"<td class='n'>{s.turnover_rate:.1f}%</td>"
+                f"<td class='n'>{s.pe_ttm:.1f}</td>"
+                f"<td class='n sc'>{s.selection_score:.1f}</td>"
+                f"<td>{tg}</td>")
+
+    def an_fn(i, s):
+        tg = " ".join(f'<span class="tg">{t}</span>' for t in s.tags)
+        return (f"<td>{i}</td><td class='tk'>{s.code}</td><td>{s.name}</td><td>{s.industry}</td>"
+                f"<td class='n {'up' if s.pct_chg>0 else 'dn'}'>{s.pct_chg:+.2f}%</td>"
+                f"<td class='n'>{s.volume_ratio:.2f}</td>"
+                f"<td class='n'>{s.turnover_rate:.1f}%</td>"
+                f"<td class='n sc'>{s.anomaly_score:.1f}</td>"
+                f"<td>{tg}</td>")
+
+    ps = sum(max(s.selection_score, .01) for s in port) or 1
+    def pt_fn(i, s):
+        w = min(max(s.selection_score, .01) / ps * 100, 35)
+        rn = "；".join(s.risk_notes[:2])
+        return (f"<td class='tk'>{s.code}</td><td>{s.name}</td><td>{s.industry}</td>"
+                f"<td class='n'>{w:.1f}%</td><td class='n'>{s.pe_ttm:.1f}</td>"
+                f"<td class='n sc'>{s.selection_score:.1f}</td><td>{rn}</td>")
+
+    def fc_fn(i, s):
+        def c(v): return 'up' if v > 0 else 'dn'
+        return (f"<td class='tk'>{s.code}</td><td>{s.name}</td>"
+                f"<td class='n {c(s.f_momentum)}'>{s.f_momentum:.1f}</td>"
+                f"<td class='n {c(s.f_volume)}'>{s.f_volume:.1f}</td>"
+                f"<td class='n {c(s.f_valuation)}'>{s.f_valuation:.1f}</td>"
+                f"<td class='n {c(s.f_growth)}'>{s.f_growth:.1f}</td>"
+                f"<td class='n {c(s.f_analyst)}'>{s.f_analyst:.1f}</td>"
+                f"<td class='n {c(s.f_risk)}'>{s.f_risk:.1f}</td>")
+
+    best = port[0] if port else None
+
+    return f"""<!doctype html><html lang="zh-CN"><head><meta charset="utf-8"><meta name="viewport" content="width=device-width,initial-scale=1">
+<title>A股量化选股报告</title>
+<style>
+:root{{--i:#0f172a;--m:#475569;--p:rgba(255,255,255,.92);--a:#0f766e;--a2:#7c3aed;--r:#dc2626;--g:#16a34a;--o:#d97706;--l:rgba(15,23,42,.08);--s:0 4px 24px rgba(15,23,42,.08)}}
+*{{box-sizing:border-box;margin:0;padding:0}}
+body{{color:var(--i);background:linear-gradient(135deg,#f0fdf4,#ecfeff 40%,#fef3c7);font-family:-apple-system,"PingFang SC","Hiragino Sans GB","Microsoft YaHei",sans-serif;line-height:1.6;padding:24px 16px 80px}}
+.ct{{max-width:1440px;margin:0 auto}}
+hd{{display:block;text-align:center;margin-bottom:36px;padding:48px 24px 36px;background:var(--p);border-radius:24px;border:1px solid var(--l);box-shadow:var(--s)}}
+hd h1{{font-size:clamp(1.8rem,4vw,3rem);letter-spacing:-.04em;background:linear-gradient(135deg,var(--a),var(--a2));-webkit-background-clip:text;-webkit-text-fill-color:transparent;margin-bottom:8px}}
+hd .mt{{color:var(--m);font-size:.9rem}}hd .mt span{{margin:0 8px}}
+.cd{{background:var(--p);border-radius:20px;border:1px solid var(--l);box-shadow:var(--s);padding:28px;margin-bottom:24px}}
+.cd h2{{font-size:1.3rem;letter-spacing:-.02em;margin-bottom:16px;padding-bottom:12px;border-bottom:2px solid var(--a);display:flex;align-items:center;gap:8px}}
+.cd h2 .nm{{color:var(--a);font-size:.85rem;font-weight:400}}
+.g2{{display:grid;grid-template-columns:1fr 1fr;gap:24px}}.g3{{display:grid;grid-template-columns:1fr 1fr 1fr;gap:24px}}
+@media(max-width:900px){{.g2,.g3{{grid-template-columns:1fr}}}}
+.kp{{text-align:center;padding:20px;border-radius:16px;background:linear-gradient(135deg,rgba(15,118,110,.06),rgba(124,58,237,.06));border:1px solid var(--l)}}
+.kp .lb{{font-size:.8rem;color:var(--m);margin-bottom:4px}}.kp .vl{{font-size:1.8rem;font-weight:700;letter-spacing:-.02em}}
+.kp .vl.up{{color:var(--r)}}.kp .vl.dn{{color:var(--g)}}.kp .vl.ac{{color:var(--a)}}
+table{{width:100%;border-collapse:separate;border-spacing:0;font-size:.83rem;overflow:hidden;border-radius:14px;border:1px solid var(--l)}}
+th{{background:#0f292a;color:#f0fdf4;text-align:left;font-weight:600;padding:10px 12px;white-space:nowrap;position:sticky;top:0;z-index:2}}
+td{{padding:8px 12px;border-bottom:1px solid var(--l);vertical-align:top}}
+tr:nth-child(even) td{{background:rgba(15,118,110,.03)}}tr:hover td{{background:rgba(124,58,237,.06)}}
+.n{{text-align:right;font-variant-numeric:tabular-nums}}.up{{color:var(--r)}}.dn{{color:var(--g)}}.sc{{font-weight:700;color:var(--a)}}
+.tk{{font-family:"SF Mono",Menlo,monospace;font-size:.82rem;color:var(--a2);font-weight:600}}
+.tg{{display:inline-block;padding:1px 8px;border-radius:8px;background:rgba(15,118,110,.1);color:var(--a);font-size:.72rem;margin:1px 2px;white-space:nowrap}}
+.rg{{display:grid;grid-template-columns:repeat(auto-fit,minmax(200px,1fr));gap:12px;margin-bottom:16px}}
+.ri{{padding:14px;border-radius:12px;background:rgba(15,118,110,.04);border:1px solid var(--l)}}.ri .dm{{font-size:.78rem;color:var(--m)}}.ri .vl{{font-size:1.1rem;font-weight:600;margin-top:4px}}
+.st{{overflow-x:auto}}.ds{{text-align:center;color:var(--m);font-size:.78rem;padding:24px;border-top:1px solid var(--l);margin-top:36px}}
+</style></head><body><div class="ct">
+
+<hd><h1>A股量化选股 — 模型驱动报告</h1>
+<div class="mt"><span>{now}</span><span>|</span><span>交易日 {sc.trade_date}</span><span>|</span>
+<span>全市场 {sc.universe_count} 只 / 过滤后 {sc.filtered_count} 只</span><span>|</span>
+<span>自适应因子模型</span></div></hd>
+
+<div class="g3" style="margin-bottom:24px">
+<div class="kp"><div class="lb">Top1 选股</div><div class="vl ac">{best.name if best else '-'}</div><div class="lb">{best.code if best else ''} — 分数 {best.selection_score if best else 0}</div></div>
+<div class="kp"><div class="lb">全市场涨跌</div><div class="vl {'up' if rg.avg_pct_chg>0 else 'dn'}">{rg.avg_pct_chg:+.2f}%</div><div class="lb">上涨 {rg.pct_positive}% | 涨停 {rg.limit_up_count} | 跌停 {rg.limit_down_count}</div></div>
+<div class="kp"><div class="lb">涨跌比</div><div class="vl ac">{rg.up_down_ratio:.2f}</div><div class="lb">平均换手 {rg.avg_turnover}% | 平均量比 {rg.avg_volume_ratio:.2f}</div></div>
+</div>
+
+<div class="cd"><h2>市场环境诊断 <span class="nm">模型驱动核心</span></h2>
+<div class="rg">
+<div class="ri"><div class="dm">波动率</div><div class="vl">{bdg(rg.volatility_level, rg.volatility_level.upper())} std={rg.std_pct_chg}%</div></div>
+<div class="ri"><div class="dm">动量环境</div><div class="vl">{bdg(rg.momentum_regime, rg.momentum_regime.upper())} avg={rg.avg_pct_chg:+.2f}%</div></div>
+<div class="ri"><div class="dm">资金面</div><div class="vl">{bdg(rg.money_flow_bias, rg.money_flow_bias.upper())} 涨跌比={rg.up_down_ratio}</div></div>
+<div class="ri"><div class="dm">市场温度</div><div class="vl">{rg.pct_positive:.1f}% 上涨</div></div>
+</div></div>
+
+<div class="g2">
+<div class="cd"><h2>模型组合 <span class="nm">Top 5</span></h2>
+<table><tr><th>代码</th><th>名称</th><th>行业</th><th>权重</th><th>PE</th><th>分数</th><th>风险</th></tr>
+{trs(port, pt_fn)}</table></div>
+<div class="cd"><h2>因子分解</h2>
+<table><tr><th>代码</th><th>名称</th><th>动量</th><th>量能</th><th>估值</th><th>成长</th><th>确认</th><th>风险</th></tr>
+{trs(port, fc_fn)}</table></div>
+</div>
+
+<div class="cd"><h2>全A选股榜 <span class="nm">Top {len(sels)} / {sc.filtered_count} 只</span></h2>
+<div class="st"><table>
+<tr><th>#</th><th>代码</th><th>名称</th><th>行业</th><th>收盘</th><th>涨跌</th><th>5日</th><th>20日</th><th>量比</th><th>换手</th><th>PE</th><th>分数</th><th>标签</th></tr>
+{trs(sels, sel_fn)}</table></div></div>
+
+<div class="cd"><h2>异动榜 <span class="nm">Top {len(anoms)}</span></h2>
+<div class="st"><table>
+<tr><th>#</th><th>代码</th><th>名称</th><th>行业</th><th>涨跌</th><th>量比</th><th>换手</th><th>异动分</th><th>标签</th></tr>
+{trs(anoms, an_fn)}</table></div></div>
+
+<div class="cd"><h2>行业分布 <span class="nm">Top 50 选股</span></h2>
+<div style="display:grid;grid-template-columns:repeat(auto-fill,minmax(160px,1fr));gap:8px">
+{"".join(f'<div style="padding:8px 12px;background:rgba(15,118,110,.06);border-radius:10px;display:flex;justify-content:space-between"><span>{ind}</span><span style="font-weight:700;color:var(--a)">{cnt}只</span></div>' for ind,cnt in ti)}
+</div></div>
+
+<div class="cd"><h2>自适应权重调整</h2>
+<table><tr><th>因子</th><th>基础</th><th>当前调整</th><th>原因</th></tr>
+<tr><td>动量</td><td>25%</td><td>{'x1.3 加强' if rg.momentum_regime=='trending' else 'x0.7 减弱' if rg.momentum_regime=='declining' else 'x1.0'}</td><td>{'趋势市顺势' if rg.momentum_regime=='trending' else '下跌市减少追涨' if rg.momentum_regime=='declining' else '中性'}</td></tr>
+<tr><td>量能</td><td>20%</td><td>x1.0</td><td>量能信号跨环境稳定</td></tr>
+<tr><td>估值</td><td>15%</td><td>{'x1.3 加重' if rg.momentum_regime=='declining' else 'x0.8 降低' if rg.momentum_regime=='trending' else 'x1.0'}</td><td>{'弱市偏防御找低估' if rg.momentum_regime=='declining' else '强市增长优先' if rg.momentum_regime=='trending' else '均衡'}</td></tr>
+<tr><td>成长</td><td>20%</td><td>{'x1.2 加重' if rg.volatility_level=='high' else 'x1.0'}</td><td>{'高波动偏好确定性成长' if rg.volatility_level=='high' else '正常'}</td></tr>
+<tr><td>量价确认</td><td>10%</td><td>x1.0</td><td>量价配合信号</td></tr>
+<tr><td>风险</td><td>10%</td><td>{'x1.4 加重惩罚' if rg.volatility_level=='high' else 'x1.0'}</td><td>{'高波动加重涨停/异常放量惩罚' if rg.volatility_level=='high' else '正常'}</td></tr>
+</table></div>
+
+<div class="ds">仅用于研究与监控，不构成投资建议。数据来源：Tushare Pro。引擎：自适应因子模型。{now}</div>
+</div></body></html>"""
+
+
+# ── Text output ──────────────────────────────────────────────────
+
+def text_report(sc: AShareScanner, top: int) -> str:
+    rg = sc.regime
+    lines = [
+        f"交易日: {sc.trade_date}  全市场: {sc.universe_count}  过滤后: {sc.filtered_count}",
+        f"市场环境: 波动={rg.volatility_level} 动量={rg.momentum_regime} 资金={rg.money_flow_bias}",
+        f"  平均涨跌={rg.avg_pct_chg:+.2f}%  上涨占比={rg.pct_positive}%  涨停={rg.limit_up_count}  跌停={rg.limit_down_count}  涨跌比={rg.up_down_ratio}",
+        "",
+        f"选股 Top {top}:",
+    ]
+    for i, s in enumerate(sc.stocks[:top], 1):
+        lines.append(
+            f"  {i:2d}. {s.code} {s.name:8s} {s.industry:6s} "
+            f"收盘={s.close:7.2f} 涨跌={s.pct_chg:+6.2f}% 5日={s.return_5d:+6.1f}% "
+            f"量比={s.volume_ratio:4.2f} 分数={s.selection_score:6.1f} 标签={s.tags}"
+        )
+    lines.append(f"\n异动 Top 10:")
+    for i, s in enumerate(sorted(sc.stocks, key=lambda x: x.anomaly_score, reverse=True)[:10], 1):
+        lines.append(
+            f"  {i:2d}. {s.code} {s.name:8s} 涨跌={s.pct_chg:+6.2f}% "
+            f"量比={s.volume_ratio:4.2f} 异动分={s.anomaly_score:.1f}"
+        )
+    return "\n".join(lines)
+
+
+# ── Main ─────────────────────────────────────────────────────────
+
+def main():
+    parser = argparse.ArgumentParser(description="A股量化选股扫描器")
+    parser.add_argument("--token", default=os.environ.get("TUSHARE_TOKEN", ""),
+                        help="Tushare Pro token (或设置 TUSHARE_TOKEN 环境变量)")
+    parser.add_argument("--codes", default="", help="指定股票代码，逗号分隔 (如 000001,600519)")
+    parser.add_argument("--top", type=int, default=30, help="显示 Top N")
+    parser.add_argument("--format", choices=["text", "json", "html", "all"], default="all")
+    parser.add_argument("--output-dir", default=".", help="报告输出目录")
+    parser.add_argument("--min-amount", type=float, default=100000, help="最小成交额阈值")
+    args = parser.parse_args()
+
+    token = args.token
+    if not token:
+        print("错误：未提供 Tushare token", file=sys.stderr)
+        print("  设置环境变量: export TUSHARE_TOKEN=your_token", file=sys.stderr)
+        print("  或传参: --token your_token", file=sys.stderr)
+        print("  免费注册: https://tushare.pro", file=sys.stderr)
+        sys.exit(1)
+
+    specific = [c.strip() for c in args.codes.split(",") if c.strip()] if args.codes else None
+
+    sc = AShareScanner(token)
+    sc.scan(top_n=args.top, min_amount=args.min_amount, specific_codes=specific)
+
+    if not sc.stocks:
+        print(json.dumps({"ok": False, "error": "未获取到股票数据"}, ensure_ascii=False))
+        sys.exit(2)
+
+    out = Path(args.output_dir)
+    out.mkdir(parents=True, exist_ok=True)
+
+    if args.format in ("text", "all"):
+        print(text_report(sc, args.top))
+
+    if args.format in ("json", "all"):
+        payload = {
+            "ok": True,
+            "created_at": datetime.now().isoformat(timespec="seconds"),
+            "trade_date": sc.trade_date,
+            "universe": sc.universe_count,
+            "filtered": sc.filtered_count,
+            "regime": asdict(sc.regime),
+            "selections": [asdict(s) for s in sc.stocks[:args.top]],
+            "anomalies": [asdict(s) for s in sorted(sc.stocks, key=lambda x: x.anomaly_score, reverse=True)[:20]],
+            "portfolio": [asdict(s) for s in sc.stocks[:5]],
+        }
+        jp = out / "a_share_scan_result.json"
+        jp.write_text(json.dumps(payload, ensure_ascii=False, indent=2), encoding="utf-8")
+        if args.format == "json":
+            print(json.dumps(payload, ensure_ascii=False, indent=2))
+
+    if args.format in ("html", "all"):
+        hp = out / "a_share_scan_report.html"
+        hp.write_text(html_report(sc), encoding="utf-8")
+        print(f"\nHTML 报告: {hp}", file=sys.stderr)
+
+    print(f"\n完成。{sc.filtered_count} 只股票已评分。", file=sys.stderr)
+
+
+if __name__ == "__main__":
+    main()

--- a/quant-scanner/SKILL.md
+++ b/quant-scanner/SKILL.md
@@ -1,0 +1,150 @@
+---
+name: quant-scanner
+description: Quantitative stock scanner with model-driven adaptive factor scoring. Scans ~100 US large/mid-cap stocks via Finnhub API, detects market regime (volatility, momentum, breadth), dynamically adjusts factor weights, and produces ranked selection/anomaly lists with HTML reports. Use for US stock screening, quantitative stock picking, factor analysis, market regime detection, stock scoring, building a model portfolio, or finding momentum/value/quality plays.
+---
+
+# Quant Scanner v1.0
+
+Model-driven quantitative stock scanner for US equities. Scans ~100 large/mid-cap stocks, detects the current market regime, adaptively adjusts 5-factor scoring weights, and outputs ranked picks with an HTML report.
+
+## Setup
+
+**Required:** A free Finnhub API key.
+
+1. Go to [https://finnhub.io](https://finnhub.io) and sign up (free)
+2. Copy your API key from the dashboard
+3. Set it as an environment variable:
+
+```bash
+export FINNHUB_API_KEY="your_key_here"
+```
+
+Or pass it directly via `--api-key`:
+
+```bash
+python3 {baseDir}/scripts/quant_scan.py --api-key YOUR_KEY
+```
+
+## Quick Commands
+
+### Full Scan (HTML + JSON report)
+
+```bash
+python3 {baseDir}/scripts/quant_scan.py
+```
+
+This will:
+1. Fetch quote, metrics, profile, and analyst recommendations for ~100 stocks
+2. Detect market regime (volatility, momentum, breadth)
+3. Score each stock on 5 adaptive factors
+4. Output a ranked list + HTML report
+
+### Quick Top 10
+
+```bash
+python3 {baseDir}/scripts/quant_scan.py --top 10
+```
+
+### Specific Tickers Only
+
+```bash
+python3 {baseDir}/scripts/quant_scan.py --tickers AAPL,NVDA,TSLA,GOOGL,META
+```
+
+### Custom Universe File
+
+```bash
+python3 {baseDir}/scripts/quant_scan.py --universe my_watchlist.txt
+```
+
+Where `my_watchlist.txt` has one ticker per line.
+
+### JSON Output Only (for piping)
+
+```bash
+python3 {baseDir}/scripts/quant_scan.py --format json
+```
+
+## How It Works
+
+### 5-Factor Adaptive Scoring
+
+Each stock is scored on 5 factors. The weights **adapt** to the detected market regime:
+
+| Factor | Base Weight | Bullish Adj | Bearish Adj | High-Vol Adj |
+| --- | ---: | --- | --- | --- |
+| **Momentum** (5D/13W/MTD return + relative strength vs S&P 500) | 30% | x1.3 boost | x0.7 dampen | — |
+| **Value** (P/E, forward P/E, PEG, dividend yield) | 20% | x0.8 reduce | x1.3 boost | — |
+| **Quality** (ROE, net margin, revenue growth, EPS growth) | 25% | — | — | x1.2 boost |
+| **Analyst Sentiment** (buy/hold/sell consensus ratio) | 10% | — | — | — |
+| **Risk-Adjusted** (beta, volatility, leverage, liquidity) | 15% | — | — | x1.4 penalty |
+
+### Market Regime Detection
+
+The scanner analyzes the full universe to determine:
+
+- **Volatility Level** — HIGH / MEDIUM / LOW (3-month average annualized std dev)
+- **Momentum Regime** — BULLISH / NEUTRAL / BEARISH (13-week return distribution)
+- **Market Breadth** — BROAD RALLY / MIXED / BROAD DECLINE (5-day positive percentage)
+
+### Data Sources (all free-tier Finnhub)
+
+| Endpoint | Data |
+| --- | --- |
+| `quote` | Current price, daily change, high/low |
+| `stock/metric` | 5D/13W/26W/52W/YTD returns, P/E, ROE, margins, beta, volatility, growth rates, relative to S&P 500 |
+| `stock/profile2` | Company name, sector, market cap |
+| `stock/recommendation` | Analyst buy/hold/sell consensus |
+
+### Default Universe (~100 stocks)
+
+**Mega Tech:** AAPL, MSFT, GOOGL, AMZN, NVDA, META, TSLA
+**Semiconductors:** AVGO, AMD, INTC, QCOM, MU, MRVL, AMAT, LRCX, KLAC, ON, ARM
+**Software/Cloud:** CRM, ORCL, ADBE, NOW, SNOW, PLTR, PANW, CRWD, DDOG, NET, ZS, SHOP
+**Financials:** JPM, V, MA, BAC, GS, MS, BLK, SCHW, AXP, C
+**Healthcare:** UNH, LLY, JNJ, ABBV, PFE, MRK, TMO, ABT, BMY, GILD, AMGN, ISRG, VRTX
+**Consumer:** WMT, COST, HD, MCD, NKE, SBUX, TGT, LOW, PG, KO, PEP
+**Energy:** XOM, CVX, COP, SLB, EOG, OXY
+**Industrials:** CAT, GE, HON, UNP, BA, RTX, LMT, DE
+**Others:** NFLX, DIS, ABNB, UBER, COIN, SOFI, SMCI, MSTR
+**China ADR:** BABA, PDD, JD, BIDU, NIO, LI, XPEV
+
+## Output
+
+### HTML Report (default)
+
+A styled, responsive HTML file with:
+- KPI dashboard (top pick, market regime, key metrics)
+- Market regime detection panel
+- Model portfolio (top 5 with factor decomposition)
+- Full selection ranking (top 30)
+- Anomaly ranking (top 20)
+- Sector distribution
+- Regime-adaptive weight explanation table
+
+### JSON Report
+
+Machine-readable output with all scored stocks, regime detection, and portfolio.
+
+## Limitations
+
+- Finnhub free tier: 60 API calls/minute — scanning 100 stocks takes ~2 minutes
+- No intraday candle data on free tier — uses metric endpoint for returns
+- Returns are point-in-time snapshots, not a real backtest
+- **Not investment advice** — research and monitoring only
+
+## Examples
+
+```
+User: scan the market and find me the best momentum plays
+→ /quant_scan
+
+User: what's the market regime right now?
+→ /quant_regime
+
+User: analyze NVDA AVGO AMD in detail
+→ /quant_analyze NVDA AVGO AMD
+
+User: give me a quick top 10 stock ranking
+→ /quant_top
+```

--- a/quant-scanner/scripts/quant_scan.py
+++ b/quant-scanner/scripts/quant_scan.py
@@ -1,0 +1,598 @@
+# /// script
+# requires-python = ">=3.9"
+# ///
+"""Quant Scanner — Model-driven adaptive US stock factor scoring.
+
+Zero external dependencies (stdlib only). Fetches data from Finnhub free-tier API,
+detects market regime, scores stocks on 5 adaptive factors, outputs HTML + JSON.
+
+Usage:
+    python3 quant_scan.py                          # Full scan, HTML report
+    python3 quant_scan.py --top 10                  # Quick top-10
+    python3 quant_scan.py --tickers AAPL,NVDA,TSLA  # Specific tickers
+    python3 quant_scan.py --format json              # JSON only
+    python3 quant_scan.py --api-key YOUR_KEY         # Pass key directly
+"""
+
+from __future__ import annotations
+
+import argparse
+import json
+import math
+import os
+import statistics
+import sys
+import time
+import urllib.error
+import urllib.request
+from dataclasses import dataclass, field, asdict
+from datetime import datetime
+from pathlib import Path
+from typing import Dict, List, Optional
+
+
+# ── Config ───────────────────────────────────────────────────────
+
+DEFAULT_UNIVERSE = [
+    "AAPL", "MSFT", "GOOGL", "AMZN", "NVDA", "META", "TSLA",
+    "AVGO", "AMD", "INTC", "QCOM", "MU", "MRVL", "AMAT", "LRCX", "KLAC", "ON", "ARM",
+    "CRM", "ORCL", "ADBE", "NOW", "SNOW", "PLTR", "PANW", "CRWD", "DDOG", "NET", "ZS", "SHOP",
+    "JPM", "V", "MA", "BAC", "GS", "MS", "BLK", "SCHW", "AXP", "C",
+    "UNH", "LLY", "JNJ", "ABBV", "PFE", "MRK", "TMO", "ABT", "BMY", "GILD", "AMGN", "ISRG", "VRTX",
+    "WMT", "COST", "HD", "MCD", "NKE", "SBUX", "TGT", "LOW", "PG", "KO", "PEP",
+    "XOM", "CVX", "COP", "SLB", "EOG", "OXY",
+    "CAT", "GE", "HON", "UNP", "BA", "RTX", "LMT", "DE",
+    "NFLX", "DIS", "ABNB", "UBER", "COIN", "SOFI",
+    "SMCI", "MSTR",
+    "BABA", "PDD", "JD", "BIDU", "NIO", "LI", "XPEV",
+]
+
+
+# ── Helpers ──────────────────────────────────────────────────────
+
+def sf(val, default=0.0) -> float:
+    try:
+        v = float(val) if val is not None else default
+        return default if math.isnan(v) or math.isinf(v) else v
+    except (TypeError, ValueError):
+        return default
+
+
+def finnhub(api_key: str, endpoint: str, params: dict | None = None) -> dict | list:
+    params = params or {}
+    params["token"] = api_key
+    qs = "&".join(f"{k}={v}" for k, v in params.items())
+    url = f"https://finnhub.io/api/v1/{endpoint}?{qs}"
+    for attempt in range(3):
+        try:
+            with urllib.request.urlopen(url, timeout=15) as resp:
+                return json.loads(resp.read())
+        except urllib.error.HTTPError as e:
+            if e.code == 429 and attempt < 2:
+                time.sleep(2)
+                continue
+            raise
+        except Exception:
+            if attempt < 2:
+                time.sleep(1)
+                continue
+            raise
+
+
+def fmt_cap(v: float) -> str:
+    if v >= 1e6:
+        return f"${v / 1e6:.1f}T"
+    if v >= 1e3:
+        return f"${v / 1e3:.0f}B"
+    return f"${v:.0f}M"
+
+
+# ── Data structures ──────────────────────────────────────────────
+
+@dataclass
+class StockData:
+    symbol: str
+    name: str
+    industry: str
+    market_cap: float
+    price: float
+    change_pct: float
+    w52_high: float
+    w52_low: float
+    return_5d: float
+    return_13w: float
+    return_26w: float
+    return_52w: float
+    return_ytd: float
+    return_mtd: float
+    rel_sp500_13w: float
+    rel_sp500_52w: float
+    rel_sp500_ytd: float
+    volatility_3m: float
+    beta: float
+    pe: float
+    forward_pe: float
+    ps: float
+    pb: float
+    peg: float
+    ev_ebitda: float
+    roe: float
+    roa: float
+    gross_margin: float
+    net_margin: float
+    revenue_growth_yoy: float
+    revenue_growth_qoq: float
+    eps_growth_yoy: float
+    eps_growth_qoq: float
+    dividend_yield: float
+    payout_ratio: float
+    current_ratio: float
+    debt_equity: float
+    analyst_buy: int
+    analyst_hold: int
+    analyst_sell: int
+
+
+@dataclass
+class Regime:
+    volatility_level: str
+    momentum_regime: str
+    breadth_bias: str
+    avg_return_5d: float
+    avg_return_13w: float
+    avg_volatility: float
+    pct_positive_5d: float
+    pct_positive_13w: float
+    pct_beating_sp500: float
+
+
+@dataclass
+class ScoredStock:
+    symbol: str
+    name: str
+    industry: str
+    market_cap: float
+    price: float
+    change_pct: float
+    return_5d: float
+    return_13w: float
+    return_52w: float
+    return_ytd: float
+    rel_sp500_ytd: float
+    pe: float
+    forward_pe: float
+    roe: float
+    revenue_growth_yoy: float
+    eps_growth_yoy: float
+    beta: float
+    volatility_3m: float
+    dividend_yield: float
+    analyst_buy: int
+    analyst_hold: int
+    analyst_sell: int
+    selection_score: float
+    anomaly_score: float
+    f_momentum: float
+    f_value: float
+    f_quality: float
+    f_analyst: float
+    f_risk: float
+    tags: List[str] = field(default_factory=list)
+    risk_notes: List[str] = field(default_factory=list)
+
+
+# ── Scanner ──────────────────────────────────────────────────────
+
+class Scanner:
+    def __init__(self, api_key: str):
+        self.api_key = api_key
+        self.stocks: List[StockData] = []
+        self.scored: List[ScoredStock] = []
+        self.regime: Optional[Regime] = None
+        self.errors: List[dict] = []
+
+    def fetch_all(self, universe: List[str], delay: float = 0.4) -> None:
+        total = len(universe)
+        for i, sym in enumerate(universe):
+            try:
+                s = self._fetch(sym)
+                if s:
+                    self.stocks.append(s)
+            except Exception as e:
+                self.errors.append({"symbol": sym, "error": str(e)[:80]})
+            if (i + 1) % 10 == 0:
+                print(f"  [{i + 1}/{total}] {len(self.stocks)} ok / {len(self.errors)} err", file=sys.stderr)
+            time.sleep(delay)
+        print(f"Fetched {len(self.stocks)} stocks ({len(self.errors)} errors)", file=sys.stderr)
+
+    def _fetch(self, sym: str) -> Optional[StockData]:
+        q = finnhub(self.api_key, "quote", {"symbol": sym})
+        if not q or sf(q.get("c")) == 0:
+            return None
+        p = finnhub(self.api_key, "stock/profile2", {"symbol": sym})
+        mx = finnhub(self.api_key, "stock/metric", {"symbol": sym, "metric": "all"}).get("metric", {})
+        recs = finnhub(self.api_key, "stock/recommendation", {"symbol": sym})
+        lr = recs[0] if recs else {}
+        return StockData(
+            symbol=sym,
+            name=(p.get("name") or sym)[:35],
+            industry=p.get("finnhubIndustry", ""),
+            market_cap=sf(p.get("marketCapitalization")),
+            price=sf(q["c"]),
+            change_pct=sf(q.get("dp")),
+            w52_high=sf(mx.get("52WeekHigh"), sf(q["c"]) * 1.1),
+            w52_low=sf(mx.get("52WeekLow"), sf(q["c"]) * 0.9),
+            return_5d=sf(mx.get("5DayPriceReturnDaily")),
+            return_13w=sf(mx.get("13WeekPriceReturnDaily")),
+            return_26w=sf(mx.get("26WeekPriceReturnDaily")),
+            return_52w=sf(mx.get("52WeekPriceReturnDaily")),
+            return_ytd=sf(mx.get("yearToDatePriceReturnDaily")),
+            return_mtd=sf(mx.get("monthToDatePriceReturnDaily")),
+            rel_sp500_13w=sf(mx.get("priceRelativeToS&P50013Week")),
+            rel_sp500_52w=sf(mx.get("priceRelativeToS&P50052Week")),
+            rel_sp500_ytd=sf(mx.get("priceRelativeToS&P500Ytd")),
+            volatility_3m=sf(mx.get("3MonthADReturnStd")),
+            beta=sf(mx.get("beta"), 1.0),
+            pe=sf(mx.get("peNormalizedAnnual")),
+            forward_pe=sf(mx.get("forwardPE")),
+            ps=sf(mx.get("psTTM")),
+            pb=sf(mx.get("pbQuarterly")),
+            peg=sf(mx.get("pegTTM")),
+            ev_ebitda=sf(mx.get("evEbitdaTTM")),
+            roe=sf(mx.get("roeTTM")),
+            roa=sf(mx.get("roaTTM")),
+            gross_margin=sf(mx.get("grossMarginTTM")),
+            net_margin=sf(mx.get("netProfitMarginTTM")),
+            revenue_growth_yoy=sf(mx.get("revenueGrowthTTMYoy")),
+            revenue_growth_qoq=sf(mx.get("revenueGrowthQuarterlyYoy")),
+            eps_growth_yoy=sf(mx.get("epsGrowthTTMYoy")),
+            eps_growth_qoq=sf(mx.get("epsGrowthQuarterlyYoy")),
+            dividend_yield=sf(mx.get("dividendYieldIndicatedAnnual")),
+            payout_ratio=sf(mx.get("payoutRatioTTM")),
+            current_ratio=sf(mx.get("currentRatioQuarterly")),
+            debt_equity=sf(mx.get("totalDebt/totalEquityQuarterly")),
+            analyst_buy=int(sf(lr.get("buy")) + sf(lr.get("strongBuy"))),
+            analyst_hold=int(sf(lr.get("hold"))),
+            analyst_sell=int(sf(lr.get("sell")) + sf(lr.get("strongSell"))),
+        )
+
+    def detect_regime(self) -> Regime:
+        r5 = [s.return_5d for s in self.stocks]
+        r13 = [s.return_13w for s in self.stocks]
+        vols = [s.volatility_3m for s in self.stocks if s.volatility_3m > 0]
+        rel = [s.rel_sp500_ytd for s in self.stocks]
+
+        avg5 = statistics.mean(r5) if r5 else 0
+        avg13 = statistics.mean(r13) if r13 else 0
+        avgv = statistics.mean(vols) if vols else 20
+        p5 = sum(1 for r in r5 if r > 0) / len(r5) * 100 if r5 else 50
+        p13 = sum(1 for r in r13 if r > 0) / len(r13) * 100 if r13 else 50
+        beat = sum(1 for r in rel if r > 0) / len(rel) * 100 if rel else 50
+
+        self.regime = Regime(
+            volatility_level="high" if avgv > 35 else ("low" if avgv < 15 else "medium"),
+            momentum_regime="bullish" if avg13 > 5 and p13 > 60 else ("bearish" if avg13 < -5 and p13 < 40 else "neutral"),
+            breadth_bias="broad_rally" if p5 > 65 else ("broad_decline" if p5 < 35 else "mixed"),
+            avg_return_5d=round(avg5, 2), avg_return_13w=round(avg13, 2),
+            avg_volatility=round(avgv, 2),
+            pct_positive_5d=round(p5, 1), pct_positive_13w=round(p13, 1),
+            pct_beating_sp500=round(beat, 1),
+        )
+        return self.regime
+
+    def score_all(self) -> List[ScoredStock]:
+        rg = self.regime or self.detect_regime()
+        bull = rg.momentum_regime == "bullish"
+        bear = rg.momentum_regime == "bearish"
+        hvol = rg.volatility_level == "high"
+
+        mb = 1.3 if bull else (0.7 if bear else 1.0)
+        vb = 1.3 if bear else (0.8 if bull else 1.0)
+        vp = 1.4 if hvol else 1.0
+        qb = 1.2 if hvol else 1.0
+
+        out = []
+        for s in self.stocks:
+            fm = s.return_5d * 0.8 * mb + s.return_13w * 0.15 * mb + s.return_mtd * 0.3 + s.rel_sp500_13w * 0.2 + s.rel_sp500_ytd * 0.1
+            pes = max(12 - abs(s.pe - 22) / 4, 0) if 0 < s.pe < 80 else 0
+            fps = max(10 - abs(s.forward_pe - 20) / 3, 0) if 0 < s.forward_pe < 60 else 0
+            pegs = max(8 - abs(s.peg - 1.2) * 3, 0) if 0 < s.peg < 5 else 0
+            fv = (pes + fps + pegs) * vb + min(s.dividend_yield * 3, 5)
+            fq = (min(s.roe / 8, 6) if s.roe > 0 else -3) + (min(s.net_margin / 5, 5) if s.net_margin > 0 else -1) + min(s.revenue_growth_yoy / 5, 8) + min(s.eps_growth_yoy / 8, 6)
+            fq *= qb
+            tot = s.analyst_buy + s.analyst_hold + s.analyst_sell
+            fa = ((s.analyst_buy / tot if tot else 0.5) - 0.5) * 25
+            fr = -abs(s.beta - 1) * 4 * vp - s.volatility_3m * 0.08 * vp - min(max(s.debt_equity - 1, 0), 3) * 2 + min(s.current_ratio, 3) * 1.5
+
+            score = fm * 0.30 + fv * 0.20 + fq * 0.25 + fa * 0.10 + fr * 0.15
+            anom = abs(s.change_pct) * 2.5 + abs(s.return_5d) * 1.2 + s.volatility_3m * 0.2 + abs(s.rel_sp500_ytd) * 0.3
+
+            tags = []
+            if s.return_5d > 8: tags.append("5D Surge")
+            elif s.return_5d > 3: tags.append("5D Strong")
+            if s.return_13w > 15: tags.append("13W Strong")
+            if s.rel_sp500_ytd > 10: tags.append("Beating S&P")
+            elif s.rel_sp500_ytd < -10: tags.append("Lagging S&P")
+            if s.revenue_growth_yoy > 20: tags.append("High Growth")
+            if s.roe > 25: tags.append("High ROE")
+            if 0 < s.pe < 15: tags.append("Value")
+            if s.analyst_buy > s.analyst_hold + s.analyst_sell: tags.append("Buy Consensus")
+            if abs(s.change_pct) > 3: tags.append("Big Mover")
+            if s.dividend_yield > 2: tags.append("Dividend")
+            if s.eps_growth_yoy > 30: tags.append("EPS Boom")
+            if not tags: tags.append("Neutral")
+
+            risks = []
+            if s.pe > 60: risks.append("Expensive")
+            if s.beta > 1.8: risks.append(f"High beta {s.beta:.1f}")
+            if s.volatility_3m > 40: risks.append("High vol")
+            if s.debt_equity > 2: risks.append("Leveraged")
+            if not risks: risks.append("Balanced")
+
+            out.append(ScoredStock(
+                symbol=s.symbol, name=s.name, industry=s.industry,
+                market_cap=s.market_cap, price=s.price, change_pct=s.change_pct,
+                return_5d=s.return_5d, return_13w=s.return_13w, return_52w=s.return_52w,
+                return_ytd=s.return_ytd, rel_sp500_ytd=s.rel_sp500_ytd,
+                pe=s.pe, forward_pe=s.forward_pe, roe=s.roe,
+                revenue_growth_yoy=s.revenue_growth_yoy, eps_growth_yoy=s.eps_growth_yoy,
+                beta=s.beta, volatility_3m=s.volatility_3m, dividend_yield=s.dividend_yield,
+                analyst_buy=s.analyst_buy, analyst_hold=s.analyst_hold, analyst_sell=s.analyst_sell,
+                selection_score=round(score, 2), anomaly_score=round(anom, 2),
+                f_momentum=round(fm, 2), f_value=round(fv, 2), f_quality=round(fq, 2),
+                f_analyst=round(fa, 2), f_risk=round(fr, 2),
+                tags=tags, risk_notes=risks,
+            ))
+
+        self.scored = sorted(out, key=lambda x: x.selection_score, reverse=True)
+        return self.scored
+
+
+# ── HTML ─────────────────────────────────────────────────────────
+
+def bdg(level: str, text: str) -> str:
+    c = {"high": "#dc2626", "low": "#16a34a", "medium": "#d97706",
+         "bullish": "#16a34a", "bearish": "#dc2626", "neutral": "#6b7280",
+         "broad_rally": "#16a34a", "broad_decline": "#dc2626", "mixed": "#6b7280"}.get(level, "#6b7280")
+    return f'<span style="display:inline-block;padding:2px 10px;border-radius:12px;background:{c}22;color:{c};font-weight:600;font-size:.85rem">{text}</span>'
+
+
+def html_report(sc: Scanner) -> str:
+    rg = sc.regime
+    scored = sc.scored
+    now = datetime.now().strftime("%Y-%m-%d %H:%M")
+    sels = [s for s in scored if s.selection_score > 0][:30]
+    anoms = sorted(scored, key=lambda x: x.anomaly_score, reverse=True)[:20]
+    port = scored[:5]
+
+    ic: Dict[str, int] = {}
+    for s in scored[:50]:
+        ic[s.industry] = ic.get(s.industry, 0) + 1
+    ti = sorted(ic.items(), key=lambda x: x[1], reverse=True)[:12]
+
+    def trs(items, cols_fn):
+        return "\n".join(f"<tr>{cols_fn(i, s)}</tr>" for i, s in enumerate(items, 1))
+
+    def sel_cols(i, s):
+        tg = " ".join(f'<span class="tg">{t}</span>' for t in s.tags)
+        return (f"<td>{i}</td><td class='tk'>{s.symbol}</td><td>{s.name}</td><td>{s.industry}</td>"
+                f"<td class='n'>${s.price:.2f}</td>"
+                f"<td class='n {'u' if s.change_pct>0 else 'd'}'>{s.change_pct:+.2f}%</td>"
+                f"<td class='n {'u' if s.return_5d>0 else 'd'}'>{s.return_5d:+.1f}%</td>"
+                f"<td class='n {'u' if s.return_13w>0 else 'd'}'>{s.return_13w:+.1f}%</td>"
+                f"<td class='n {'u' if s.return_ytd>0 else 'd'}'>{s.return_ytd:+.1f}%</td>"
+                f"<td class='n'>{s.pe:.1f}</td><td class='n'>{s.roe:.1f}%</td>"
+                f"<td class='n'>{s.revenue_growth_yoy:+.1f}%</td>"
+                f"<td class='n'>{s.eps_growth_yoy:+.1f}%</td>"
+                f"<td class='n sc'>{s.selection_score:.1f}</td><td>{tg}</td>")
+
+    def an_cols(i, s):
+        tg = " ".join(f'<span class="tg">{t}</span>' for t in s.tags)
+        return (f"<td>{i}</td><td class='tk'>{s.symbol}</td><td>{s.name}</td>"
+                f"<td class='n {'u' if s.change_pct>0 else 'd'}'>{s.change_pct:+.2f}%</td>"
+                f"<td class='n'>{s.return_5d:+.1f}%</td><td class='n'>{s.volatility_3m:.1f}%</td>"
+                f"<td class='n'>{s.beta:.2f}</td><td class='n sc'>{s.anomaly_score:.1f}</td><td>{tg}</td>")
+
+    ps = sum(max(s.selection_score, .01) for s in port) or 1
+    def pt_cols(i, s):
+        w = min(max(s.selection_score, .01) / ps * 100, 35)
+        rn = "; ".join(s.risk_notes[:2])
+        return (f"<td class='tk'>{s.symbol}</td><td>{s.name}</td><td class='n'>{w:.1f}%</td>"
+                f"<td class='n'>{fmt_cap(s.market_cap)}</td><td class='n'>{s.pe:.1f}</td>"
+                f"<td class='n'>{s.roe:.1f}%</td><td class='n sc'>{s.selection_score:.1f}</td><td>{rn}</td>")
+
+    def fc_cols(i, s):
+        def c(v): return 'u' if v > 0 else 'd'
+        return (f"<td class='tk'>{s.symbol}</td><td>{s.name}</td>"
+                f"<td class='n {c(s.f_momentum)}'>{s.f_momentum:.1f}</td>"
+                f"<td class='n {c(s.f_value)}'>{s.f_value:.1f}</td>"
+                f"<td class='n {c(s.f_quality)}'>{s.f_quality:.1f}</td>"
+                f"<td class='n {c(s.f_analyst)}'>{s.f_analyst:.1f}</td>"
+                f"<td class='n {c(s.f_risk)}'>{s.f_risk:.1f}</td>")
+
+    best = port[0] if port else None
+
+    return f"""<!doctype html><html lang="en"><head><meta charset="utf-8"><meta name="viewport" content="width=device-width,initial-scale=1">
+<title>US Quant Scanner</title>
+<style>
+:root{{--i:#0f172a;--m:#475569;--p:rgba(255,255,255,.92);--a:#1d4ed8;--a2:#7c3aed;--r:#dc2626;--g:#16a34a;--o:#d97706;--l:rgba(15,23,42,.08);--s:0 4px 24px rgba(15,23,42,.08)}}
+*{{box-sizing:border-box;margin:0;padding:0}}
+body{{color:var(--i);background:linear-gradient(135deg,#eff6ff,#f5f3ff 40%,#fefce8);font-family:-apple-system,"SF Pro","Segoe UI",sans-serif;line-height:1.6;padding:24px 16px 80px}}
+.ct{{max-width:1440px;margin:0 auto}}
+hd{{display:block;text-align:center;margin-bottom:36px;padding:48px 24px 36px;background:var(--p);border-radius:24px;border:1px solid var(--l);box-shadow:var(--s)}}
+hd h1{{font-size:clamp(1.8rem,4vw,3rem);letter-spacing:-.04em;background:linear-gradient(135deg,var(--a),var(--a2));-webkit-background-clip:text;-webkit-text-fill-color:transparent;margin-bottom:8px}}
+hd .mt{{color:var(--m);font-size:.9rem}}hd .mt span{{margin:0 8px}}
+.cd{{background:var(--p);border-radius:20px;border:1px solid var(--l);box-shadow:var(--s);padding:28px;margin-bottom:24px}}
+.cd h2{{font-size:1.3rem;letter-spacing:-.02em;margin-bottom:16px;padding-bottom:12px;border-bottom:2px solid var(--a);display:flex;align-items:center;gap:8px}}
+.cd h2 .nm{{color:var(--a);font-size:.85rem;font-weight:400}}
+.g2{{display:grid;grid-template-columns:1fr 1fr;gap:24px}}.g3{{display:grid;grid-template-columns:1fr 1fr 1fr;gap:24px}}
+@media(max-width:900px){{.g2,.g3{{grid-template-columns:1fr}}}}
+.kp{{text-align:center;padding:20px;border-radius:16px;background:linear-gradient(135deg,rgba(29,78,216,.06),rgba(124,58,237,.06));border:1px solid var(--l)}}
+.kp .lb{{font-size:.8rem;color:var(--m);margin-bottom:4px}}.kp .vl{{font-size:1.8rem;font-weight:700;letter-spacing:-.02em}}
+.kp .vl.u{{color:var(--g)}}.kp .vl.d{{color:var(--r)}}.kp .vl.ac{{color:var(--a)}}
+table{{width:100%;border-collapse:separate;border-spacing:0;font-size:.83rem;overflow:hidden;border-radius:14px;border:1px solid var(--l)}}
+th{{background:#1e293b;color:#f8fafc;text-align:left;font-weight:600;padding:10px 12px;white-space:nowrap;position:sticky;top:0;z-index:2}}
+td{{padding:8px 12px;border-bottom:1px solid var(--l);vertical-align:top}}
+tr:nth-child(even) td{{background:rgba(29,78,216,.03)}}tr:hover td{{background:rgba(124,58,237,.06)}}
+.n{{text-align:right;font-variant-numeric:tabular-nums}}.u{{color:var(--g)}}.d{{color:var(--r)}}.sc{{font-weight:700;color:var(--a)}}
+.tk{{font-family:"SF Mono",Menlo,monospace;font-size:.82rem;color:var(--a2);font-weight:600}}
+.tg{{display:inline-block;padding:1px 8px;border-radius:8px;background:rgba(29,78,216,.1);color:var(--a);font-size:.72rem;margin:1px 2px;white-space:nowrap}}
+.rg{{display:grid;grid-template-columns:repeat(auto-fit,minmax(200px,1fr));gap:12px;margin-bottom:16px}}
+.ri{{padding:14px;border-radius:12px;background:rgba(29,78,216,.04);border:1px solid var(--l)}}.ri .dm{{font-size:.78rem;color:var(--m)}}.ri .vl{{font-size:1.1rem;font-weight:600;margin-top:4px}}
+.st{{overflow-x:auto}}.ds{{text-align:center;color:var(--m);font-size:.78rem;padding:24px;border-top:1px solid var(--l);margin-top:36px}}
+</style></head><body><div class="ct">
+
+<hd><h1>US Stock Quant Scanner</h1>
+<div class="mt"><span>{now}</span><span>|</span><span>{len(sc.stocks)} stocks scanned</span><span>|</span><span>Finnhub API</span><span>|</span><span>Adaptive Factor Model</span></div></hd>
+
+<div class="g3" style="margin-bottom:24px">
+<div class="kp"><div class="lb">Top Pick</div><div class="vl ac">{best.symbol if best else '-'}</div><div class="lb">{best.name if best else ''} &mdash; Score {best.selection_score if best else 0}</div></div>
+<div class="kp"><div class="lb">13W Avg Return</div><div class="vl {'u' if rg.avg_return_13w>0 else 'd'}">{rg.avg_return_13w:+.1f}%</div><div class="lb">{rg.pct_positive_13w}% positive</div></div>
+<div class="kp"><div class="lb">Beating S&P YTD</div><div class="vl ac">{rg.pct_beating_sp500}%</div><div class="lb">of universe</div></div>
+</div>
+
+<div class="cd"><h2>Market Regime <span class="nm">Adaptive Core</span></h2>
+<div class="rg">
+<div class="ri"><div class="dm">Volatility</div><div class="vl">{bdg(rg.volatility_level, rg.volatility_level.upper())} {rg.avg_volatility:.1f}%</div></div>
+<div class="ri"><div class="dm">Momentum (13W)</div><div class="vl">{bdg(rg.momentum_regime, rg.momentum_regime.upper())} {rg.avg_return_13w:+.1f}%</div></div>
+<div class="ri"><div class="dm">Breadth (5D)</div><div class="vl">{bdg(rg.breadth_bias, rg.breadth_bias.replace('_',' ').upper())} {rg.pct_positive_5d}%+</div></div>
+<div class="ri"><div class="dm">5D Avg Return</div><div class="vl">{rg.avg_return_5d:+.2f}%</div></div>
+</div></div>
+
+<div class="g2">
+<div class="cd"><h2>Model Portfolio <span class="nm">Top 5</span></h2>
+<table><tr><th>Ticker</th><th>Name</th><th>Wt</th><th>MCap</th><th>P/E</th><th>ROE</th><th>Score</th><th>Risk</th></tr>
+{trs(port, pt_cols)}</table></div>
+<div class="cd"><h2>Factor Decomposition</h2>
+<table><tr><th>Ticker</th><th>Name</th><th>Mom</th><th>Val</th><th>Qual</th><th>Anlst</th><th>Risk</th></tr>
+{trs(port, fc_cols)}</table></div>
+</div>
+
+<div class="cd"><h2>Selection Ranking <span class="nm">Top {len(sels)}</span></h2>
+<div class="st"><table><tr><th>#</th><th>Ticker</th><th>Name</th><th>Sector</th><th>Price</th><th>Chg</th><th>5D</th><th>13W</th><th>YTD</th><th>P/E</th><th>ROE</th><th>RevGr</th><th>EPSGr</th><th>Score</th><th>Tags</th></tr>
+{trs(sels, sel_cols)}</table></div></div>
+
+<div class="cd"><h2>Anomaly Ranking <span class="nm">Top {len(anoms)}</span></h2>
+<div class="st"><table><tr><th>#</th><th>Ticker</th><th>Name</th><th>Chg</th><th>5D</th><th>Vol3M</th><th>Beta</th><th>Anom</th><th>Tags</th></tr>
+{trs(anoms, an_cols)}</table></div></div>
+
+<div class="cd"><h2>Sector Distribution <span class="nm">Top 50</span></h2>
+<div style="display:grid;grid-template-columns:repeat(auto-fill,minmax(180px,1fr));gap:8px">
+{"".join(f'<div style="padding:8px 14px;background:rgba(29,78,216,.06);border-radius:10px;display:flex;justify-content:space-between"><span>{ind}</span><span style="font-weight:700;color:var(--a)">{cnt}</span></div>' for ind,cnt in ti)}
+</div></div>
+
+<div class="cd"><h2>Adaptive Weight Table</h2>
+<table><tr><th>Factor</th><th>Base</th><th>Current Adj</th><th>Rationale</th></tr>
+<tr><td>Momentum</td><td>30%</td><td>{'x1.3' if rg.momentum_regime=='bullish' else 'x0.7' if rg.momentum_regime=='bearish' else 'x1.0'}</td><td>{'Bullish — ride trend' if rg.momentum_regime=='bullish' else 'Bearish — dampen chase' if rg.momentum_regime=='bearish' else 'Neutral'}</td></tr>
+<tr><td>Value</td><td>20%</td><td>{'x1.3' if rg.momentum_regime=='bearish' else 'x0.8' if rg.momentum_regime=='bullish' else 'x1.0'}</td><td>{'Bearish — flight to value' if rg.momentum_regime=='bearish' else 'Bullish — growth favored' if rg.momentum_regime=='bullish' else 'Balanced'}</td></tr>
+<tr><td>Quality</td><td>25%</td><td>{'x1.2' if rg.volatility_level=='high' else 'x1.0'}</td><td>{'High vol — quality premium' if rg.volatility_level=='high' else 'Normal'}</td></tr>
+<tr><td>Analyst</td><td>10%</td><td>x1.0</td><td>Stable across regimes</td></tr>
+<tr><td>Risk</td><td>15%</td><td>{'x1.4' if rg.volatility_level=='high' else 'x1.0'}</td><td>{'High vol — heavier penalty' if rg.volatility_level=='high' else 'Normal'}</td></tr>
+</table></div>
+
+<div class="ds">For research only — not investment advice. Data: Finnhub (free tier). Engine: Adaptive Factor Model. {now}</div>
+</div></body></html>"""
+
+
+# ── Text output ──────────────────────────────────────────────────
+
+def text_report(sc: Scanner, top: int) -> str:
+    rg = sc.regime
+    scored = sc.scored
+    lines = [
+        f"Market Regime: vol={rg.volatility_level} mom={rg.momentum_regime} breadth={rg.breadth_bias}",
+        f"  5D avg={rg.avg_return_5d:+.2f}%  13W avg={rg.avg_return_13w:+.2f}%  vol={rg.avg_volatility:.1f}%",
+        f"  {rg.pct_positive_5d}% positive 5D | {rg.pct_positive_13w}% positive 13W | {rg.pct_beating_sp500}% beating S&P",
+        "",
+        f"Top {top} Selections:",
+    ]
+    for i, s in enumerate(scored[:top], 1):
+        lines.append(
+            f"  {i:2d}. {s.symbol:6s} {s.name:28s} score={s.selection_score:6.1f} "
+            f"5D={s.return_5d:+6.1f}% YTD={s.return_ytd:+7.1f}% PE={s.pe:5.1f} "
+            f"ROE={s.roe:6.1f}% tags={s.tags}"
+        )
+    lines.append(f"\nTop 10 Anomalies:")
+    for i, s in enumerate(sorted(scored, key=lambda x: x.anomaly_score, reverse=True)[:10], 1):
+        lines.append(
+            f"  {i:2d}. {s.symbol:6s} chg={s.change_pct:+5.2f}% 5D={s.return_5d:+6.1f}% "
+            f"vol={s.volatility_3m:5.1f}% anom={s.anomaly_score:.1f}"
+        )
+    return "\n".join(lines)
+
+
+# ── Main ─────────────────────────────────────────────────────────
+
+def main():
+    parser = argparse.ArgumentParser(description="US Stock Quant Scanner")
+    parser.add_argument("--api-key", default=os.environ.get("FINNHUB_API_KEY", ""),
+                        help="Finnhub API key (or set FINNHUB_API_KEY env var)")
+    parser.add_argument("--tickers", default="", help="Comma-separated tickers (default: full universe)")
+    parser.add_argument("--universe", default="", help="File with one ticker per line")
+    parser.add_argument("--top", type=int, default=30, help="Top N to display")
+    parser.add_argument("--format", choices=["text", "json", "html", "all"], default="all",
+                        help="Output format (default: all)")
+    parser.add_argument("--output-dir", default=".", help="Output directory for reports")
+    parser.add_argument("--delay", type=float, default=0.4, help="Delay between API calls (seconds)")
+    args = parser.parse_args()
+
+    api_key = args.api_key
+    if not api_key:
+        print("Error: No Finnhub API key. Set FINNHUB_API_KEY or use --api-key.", file=sys.stderr)
+        print("Get a free key at https://finnhub.io", file=sys.stderr)
+        sys.exit(1)
+
+    # Determine universe
+    if args.tickers:
+        universe = [t.strip().upper() for t in args.tickers.split(",") if t.strip()]
+    elif args.universe:
+        universe = [l.strip().upper() for l in Path(args.universe).read_text().splitlines() if l.strip() and not l.startswith("#")]
+    else:
+        universe = DEFAULT_UNIVERSE
+
+    print(f"Quant Scanner: {len(universe)} tickers, format={args.format}", file=sys.stderr)
+
+    sc = Scanner(api_key)
+    sc.fetch_all(universe, delay=args.delay)
+
+    if not sc.stocks:
+        print(json.dumps({"ok": False, "error": "No stocks fetched", "errors": sc.errors}))
+        sys.exit(2)
+
+    sc.detect_regime()
+    sc.score_all()
+
+    out_dir = Path(args.output_dir)
+    out_dir.mkdir(parents=True, exist_ok=True)
+
+    if args.format in ("text", "all"):
+        txt = text_report(sc, args.top)
+        print(txt)
+
+    if args.format in ("json", "all"):
+        payload = {
+            "ok": True,
+            "created_at": datetime.now().isoformat(timespec="seconds"),
+            "universe": len(sc.stocks),
+            "errors": sc.errors,
+            "regime": asdict(sc.regime),
+            "top_selections": [asdict(s) for s in sc.scored[:args.top]],
+            "top_anomalies": [asdict(s) for s in sorted(sc.scored, key=lambda x: x.anomaly_score, reverse=True)[:20]],
+            "portfolio": [asdict(s) for s in sc.scored[:5]],
+        }
+        jp = out_dir / "quant_scan_result.json"
+        jp.write_text(json.dumps(payload, ensure_ascii=False, indent=2), encoding="utf-8")
+        if args.format == "json":
+            print(json.dumps(payload, ensure_ascii=False, indent=2))
+
+    if args.format in ("html", "all"):
+        html = html_report(sc)
+        hp = out_dir / "quant_scan_report.html"
+        hp.write_text(html, encoding="utf-8")
+        print(f"\nHTML report: {hp}", file=sys.stderr)
+
+    print(f"\nDone. {len(sc.stocks)} stocks scored.", file=sys.stderr)
+
+
+if __name__ == "__main__":
+    main()


### PR DESCRIPTION
## Summary

Two model-driven quantitative stock scanning skills covering both US and Chinese markets:

- **quant-scanner**: US equities (~100 large/mid-cap, Finnhub API, free tier)
- **a-share-scanner**: Chinese A-shares (5000+ stocks, Tushare Pro, free tier)

## How They Work

Both skills use the same architecture:

1. **Fetch** real-time quotes + fundamental metrics from free API
2. **Detect** market regime (volatility, momentum, breadth/money flow)
3. **Score** each stock on adaptive multi-factor model (weights adjust to regime)
4. **Output** ranked lists + HTML report + JSON

### quant-scanner (US)

| Factor | Weight | Adapts to |
| --- | --- | --- |
| Momentum (5D/13W/MTD + S&P relative) | 30% | Bull x1.3 / Bear x0.7 |
| Value (P/E, fwd P/E, PEG, div yield) | 20% | Bear x1.3 / Bull x0.8 |
| Quality (ROE, margin, growth) | 25% | High-vol x1.2 |
| Analyst (consensus ratio) | 10% | Stable |
| Risk (beta, vol, leverage) | 15% | High-vol x1.4 |

- Zero external dependencies (Python stdlib only)
- User provides free Finnhub API key

### a-share-scanner (A-shares)

| Factor | Weight | Adapts to |
| --- | --- | --- |
| Momentum (daily + 5D + 20D) | 25% | Trending x1.3 / Declining x0.7 |
| Volume (ratio + turnover + amount) | 20% | Stable |
| Valuation (PE/PB) | 15% | Declining x1.3 |
| Growth (multi-period momentum) | 20% | High-vol x1.2 |
| Price-Volume Confirmation | 10% | Stable |
| Risk (limit-up chase, excess vol) | 10% | High-vol x1.4 |

- Requires: tushare + pandas
- User provides free Tushare Pro token

## Test plan

- [x] US: 91/93 stocks fetched successfully, HTML/JSON/text output verified
- [x] A-shares: 3080/5494 stocks scored (after ST/liquidity filter), HTML output verified
- [x] Both work with Python 3.9+
- [x] Graceful error handling for API rate limits

🤖 Generated with [Claude Code](https://claude.ai/claude-code)