### PR TITLE
chore: expand .gitignore for local artifacts

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,2 +1,8 @@
 node_modules/
+dist/
+build/
+.cache/
+coverage/
+*.log
 .DS_Store
+Thumbs.db


### PR DESCRIPTION
Adds common local artifact ignore patterns to reduce accidental commits:\n\n- dist/, build/, .cache/, coverage/\n- *.log\n- .DS_Store, Thumbs.db\n\nNo source changes.