### PR TITLE
Add book-to-skill: Convert books/documents into agent skills

### DIFF
--- a/book-to-skill/CONTRIBUTING.md
+++ b/book-to-skill/CONTRIBUTING.md
@@ -1,0 +1,131 @@
+# Submitting book-to-skill to pi-skills
+
+This document contains instructions for submitting the `book-to-skill` skill to the [badlogic/pi-skills](https://github.com/badlogic/pi-skills) repository.
+
+## Pre-submission Checklist
+
+- [x] `SKILL.md` with valid frontmatter (name, description)
+- [x] `README.md` with installation and usage instructions
+- [x] `LICENSE` file (MIT)
+- [x] `scripts/extract.py` working and tested
+- [x] Skill name matches directory name
+- [x] Description under 1024 characters
+- [x] No invalid characters in name (lowercase a-z, 0-9, hyphens only)
+
+## Submission Steps
+
+### Option 1: Manual PR (Recommended)
+
+```bash
+# 1. Fork and clone the pi-skills repository
+git clone https://github.com/badlogic/pi-skills
+cd pi-skills
+
+# 2. Copy the skill
+cp -r /path/to/book-to-skill ./book-to-skill
+
+# 3. Create a feature branch
+git checkout -b feature/add-book-to-skill
+
+# 4. Add the skill
+git add book-to-skill/
+
+# 5. Commit
+git commit -m "Add book-to-skill: Convert books/documents into agent skills
+
+- Supports PDF, EPUB, DOCX, HTML, Markdown, TXT, RTF, MOBI/AZW
+- Extracts frameworks, mental models, principles, and techniques
+- Creates structured skills with chapters, glossary, patterns, cheatsheet
+- Cost-optimized for large books (>50k tokens)
+- Compatible with pi, Claude Code, Amp, and Droid"
+
+# 6. Push
+git push origin feature/add-book-to-skill
+
+# 7. Open a Pull Request at:
+# https://github.com/badlogic/pi-skills/compare
+```
+
+### Option 2: Use publish-skills CLI
+
+```bash
+# Install the publishing tool
+npm install -g publish-skills
+
+# Login to GitHub
+npx publish-skills login
+
+# Validate the skill
+npx publish-skills validate ~/.pi/agent/skills/book-to-skill
+
+# Publish (creates PR automatically)
+npx publish-skills publish ~/.pi/agent/skills/book-to-skill
+```
+
+## PR Description Template
+
+```markdown
+## book-to-skill
+
+A skill that converts books and documents into structured agent skills.
+
+### Features
+
+- **Multi-format support**: PDF, EPUB, DOCX, HTML, Markdown, TXT, RTF, MOBI/AZW
+- **Structure-aware extraction**: Preserves tables, code blocks, and formulas (technical mode)
+- **Cost-optimized**: Uses REPL-style access for large books (>50k tokens)
+- **Complete output**: Generates SKILL.md, chapter summaries, glossary, patterns, and cheatsheet
+- **Agent-agnostic**: Compatible with pi, Claude Code, Amp, and Droid
+
+### Requirements
+
+- Python 3.6+
+- Optional: `PyPDF2`, `python-docx`, `ebooklib`, `beautifulsoup4`, `docling`
+- Optional: Calibre (for MOBI/AZW formats)
+
+### Testing
+
+Tested with:
+- Technical books (programming, architecture)
+- Non-fiction (management, productivity)
+- Various formats (PDF, EPUB, DOCX)
+
+### Files Added
+
+- `book-to-skill/SKILL.md` - Main skill definition
+- `book-to-skill/README.md` - Documentation
+- `book-to-skill/LICENSE` - MIT license
+- `book-to-skill/scripts/extract.py` - Text extraction script
+```
+
+## After PR is Merged
+
+Users can install the skill with:
+
+```bash
+# Clone the pi-skills repository
+git clone https://github.com/badlogic/pi-skills ~/.pi/agent/skills/pi-skills
+
+# Or symlink just this skill
+ln -s ~/.pi/agent/skills/pi-skills/book-to-skill ~/.pi/agent/skills/book-to-skill
+```
+
+Then use with:
+
+```bash
+/skill:book-to-skill /path/to/book.pdf my-skill-name
+```
+
+## Maintenance
+
+To update the skill after it's published:
+
+1. Update files in your local copy
+2. Sync to `~/.pi/agent/skills/book-to-skill/`
+3. Submit a PR to update the skill in pi-skills repo
+
+## Support
+
+For issues or questions:
+- Open an issue in your fork
+- Contact the pi-skills maintainers: @badlogic, @terrorobe

--- a/book-to-skill/LICENSE
+++ b/book-to-skill/LICENSE
@@ -1,0 +1,21 @@
+MIT License
+
+Copyright (c) 2026 book-to-skill contributors
+
+Permission is hereby granted, free of charge, to any person obtaining a copy
+of this software and associated documentation files (the "Software"), to deal
+in the Software without restriction, including without limitation the rights
+to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+copies of the Software, and to permit persons to whom the Software is
+furnished to do so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in all
+copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+SOFTWARE.

--- a/book-to-skill/README.md
+++ b/book-to-skill/README.md
@@ -1,0 +1,190 @@
+# book-to-skill
+
+Convert books and documents into structured agent skills that can be used repeatedly in pi, Claude Code, Amp, and other compatible AI agents.
+
+## Installation
+
+```bash
+# Clone the pi-skills repository (includes this skill)
+git clone https://github.com/badlogic/pi-skills ~/.pi/agent/skills/pi-skills
+
+# Or install just this skill
+git clone https://github.com/badlogic/pi-skills.git
+ln -s pi-skills/book-to-skill ~/.pi/agent/skills/book-to-skill
+```
+
+## Usage
+
+```bash
+# In pi, use the skill command
+/skill:book-to-skill
+
+# Then provide a book path
+/path/to/book.pdf my-skill-name
+```
+
+## Supported Formats
+
+| Format | Extensions | Notes |
+|--------|-----------|-------|
+| PDF | `.pdf`, `.PDF` | Fast text extraction or structure-aware (Docling) |
+| EPUB | `.epub`, `.EPUB` | Uses ebooklib or ZIP fallback |
+| Word | `.docx`, `.DOCX` | Uses python-docx or ZIP/XML fallback |
+| Plain Text | `.txt`, `.md`, `.markdown` | Direct read |
+| HTML | `.html`, `.htm`, `.HTML` | BeautifulSoup or regex fallback |
+| RTF | `.rtf`, `.RTF` | striprtf or regex fallback |
+| E-book | `.mobi`, `.azw`, `.azw3` | Requires Calibre |
+
+## Requirements
+
+### Python Dependencies
+
+The extractor will prompt to install missing packages, or pre-install:
+
+```bash
+# Core extraction (recommended)
+pip install PyPDF2 python-docx ebooklib beautifulsoup4 striprtf
+
+# Technical PDF extraction (structure-aware, preserves tables/code)
+pip install docling
+
+# Alternative PDF extraction
+pip install pdfminer-six
+```
+
+### Calibre (for MOBI/AZW formats)
+
+```bash
+# macOS
+brew install calibre
+
+# Linux
+sudo apt install calibre
+
+# Windows
+# Download from https://calibre-ebook.com/download
+```
+
+## How It Works
+
+### 1. Extraction
+- Validates file format
+- Extracts text using the best available method
+- Preserves structure for technical documents (tables, code blocks)
+
+### 2. Analysis
+- Identifies book title, author, chapter structure
+- Extracts frameworks, principles, techniques
+- Maps topics to chapters
+
+### 3. Generation
+Creates a complete skill with:
+- `SKILL.md` - Core frameworks and mental models
+- `chapters/` - Individual chapter summaries (loaded on-demand)
+- `glossary.md` - All key terms alphabetically
+- `patterns.md` - Techniques and design patterns
+- `cheatsheet.md` - Quick reference tables
+
+### 4. Cost Optimization
+
+For large books (>50k tokens), uses REPL-style access:
+- `grep` to find chapter offsets
+- `sed` to extract only needed sections
+- Never loads entire book into context
+
+## Output Structure
+
+```
+~/.config/agents/skills/{skill-name}/
+├── SKILL.md              # Main skill file (~4K tokens)
+├── chapters/             # Chapter summaries (on-demand)
+│   ├── ch01-intro.md
+│   ├── ch02-frameworks.md
+│   └── ...
+├── glossary.md           # Key terms (~1.5K tokens)
+├── patterns.md           # Techniques (~2K tokens)
+└── cheatsheet.md         # Quick reference (~1K tokens)
+```
+
+## Usage Examples
+
+### After Creating a Skill
+
+```bash
+# Load core frameworks
+Ask: "{skill-name}"
+
+# Ask about a specific topic
+Ask: "{skill-name} about replication"
+
+# Read a specific chapter
+Ask: "{skill-name} for ch05"
+
+# Browse all chapters
+Ask: "What chapters do you have?"
+```
+
+### Integration with Agents
+
+The generated skill is compatible with:
+- **pi** (default: `~/.pi/agent/skills/`)
+- **Claude Code** (`~/.claude/skills/`)
+- **Amp** (`~/.config/agents/skills/`)
+- Project-local (`.pi/skills/`, `.agents/skills/`)
+
+## Token Budget Guidelines
+
+| File | Target Size | When Loaded |
+|------|-------------|-------------|
+| SKILL.md | ~4,000 tokens | Always (skill activation) |
+| chapters/* | 800-1,200 each | On-demand only |
+| glossary.md | ~1,500 tokens | On-demand only |
+| patterns.md | ~2,000 tokens | On-demand only |
+| cheatsheet.md | ~1,000 tokens | On-demand only |
+
+**Total skill size**: ~10-15K tokens, but only ~4K loaded by default.
+
+## Environment Variables
+
+| Variable | Default | Description |
+|----------|---------|-------------|
+| `BOOK_SKILL_WORKDIR` | `/tmp/book_skill_work` | Working directory for extraction |
+| `BOOK_SKILL_INSTALL_MISSING` | `ask` | Install packages: `yes`/`no`/`ask` |
+| `PYTHON_BIN` | `python3` | Python interpreter to use |
+
+## Troubleshooting
+
+### "No suitable extractor available"
+Install the required package:
+```bash
+pip install PyPDF2  # for PDF
+pip install ebooklib beautifulsoup4  # for EPUB
+pip install python-docx  # for DOCX
+```
+
+### "Calibre not installed" (MOBI/AZW)
+Install Calibre from https://calibre-ebook.com/download
+
+### Extraction is slow for PDFs
+- Text mode: uses fast pdftotext if available
+- Technical mode: uses Docling (~1.5s/page) for structure
+
+### Out of memory for large books
+Set a custom work directory with more space:
+```bash
+export BOOK_SKILL_WORKDIR=/path/to/large/disk
+```
+
+## Philosophy
+
+This tool extracts **structure, not summaries**:
+- Named frameworks with exact formulations
+- Actionable principles ("Use X when Y")
+- Techniques with step-by-step methods
+- Anti-patterns and what to avoid
+
+The goal is to create a **reusable toolkit** from books, not a book report.
+
+## License
+
+MIT

--- a/book-to-skill/SKILL.md
+++ b/book-to-skill/SKILL.md
@@ -1,0 +1,517 @@
+---
+name: book-to-skill
+description: Converts books and documents (PDF, EPUB, DOCX, HTML, Markdown, text, RTF, MOBI/AZW) into structured agent skills with frameworks, mental models, principles, and techniques. Use when you want to study a document, apply an author's frameworks while working, or build a reusable knowledge base from a book.
+---
+
+# Book-to-Skill Converter
+
+Transform written knowledge into actionable agent skills by extracting structure — not producing summaries.
+
+**Helper scripts**: `{baseDir}/scripts/extract.py`
+
+## Quick Start
+
+```bash
+/skill:book-to-skill /path/to/book.pdf my-skill-name
+```
+
+This will:
+1. Validate the document format
+2. Ask about content type (technical vs text-heavy)
+3. Extract text using the best available method
+4. Show a cost estimate before generating
+5. Create a complete skill with chapters, glossary, patterns, and cheatsheet
+
+## Philosophy
+
+Books contain crystallized expertise: frameworks, principles, and techniques that took years to develop. This skill extracts that knowledge into a format Amp, Claude Code, or another compatible agent can leverage repeatedly.
+
+**Extract structure, not summaries.** A skill isn't a book report. It's a toolkit of:
+- Named frameworks (mental models with clear application)
+- Actionable principles (rules that guide decisions)
+- Techniques (step-by-step methods)
+- Anti-patterns (what to avoid and why)
+- Voice calibration (how the author thinks and communicates)
+
+**Preserve the author's precision.** Frameworks often have specific names for reasons. "The 5 Whys" isn't interchangeable with "ask why multiple times." Capture the exact formulation.
+
+**Layer depth appropriately.** Simple books → simple skills. Complex books with 10+ frameworks → skills with reference files and on-demand chapters.
+
+---
+
+## Modes of Operation
+
+Three paths available. Route based on what the user asks:
+
+### 1. Full Conversion (Default)
+**Trigger:** User provides a supported document path without special instructions
+**Action:** Run all steps below (Steps 0–9)
+**Output:** Complete skill with SKILL.md, chapters/, glossary, patterns, cheatsheet
+
+### 2. Analyze Only
+**Trigger:** User says "analyze", "just extract", or "I want to review before generating"
+**Action:** Run Steps 0–3, then produce a structured extraction report (frameworks, principles, techniques found). Stop — do NOT generate skill files.
+**Output:** Analysis report for user review
+
+### 3. Generate from Prior Analysis
+**Trigger:** User has existing analysis notes or previously ran analyze-only
+**Action:** Skip Steps 0–3, use the provided analysis as input, run Steps 4–9
+**Output:** Skill files from the provided analysis
+
+---
+
+## Skill Locations
+
+This converter can run from multiple skill systems. When looking for this converter's helper script or writing the generated book skill, prefer these locations in order:
+
+1. Amp project-local skills: `.agents/skills/`
+2. Amp global skills: `~/.config/agents/skills/`
+3. Amp legacy global skills: `~/.config/amp/skills/`
+4. Claude Code skills: `~/.claude/skills/`
+
+Generated skills should default to `~/.config/agents/skills/` for Amp unless the user asks for project-local or Claude Code output.
+
+---
+
+## Step 0 — Out-of-scope check
+
+If the argument is NOT a path to a supported document file, stop and respond:
+> "book-to-skill requires a supported document path. Usage: `book-to-skill /path/to/book.pdf [skill-name]`, `book-to-skill /path/to/book.epub [skill-name]`, or another supported format such as `.docx`, `.md`, `.txt`, `.html`, `.rtf`, `.mobi`, or `.azw3`."
+
+Throughout the workflow, treat the first argument as `BOOK_PATH` and the optional second argument as `SKILL_NAME`.
+
+---
+
+## Step 1 — Validate input
+
+```bash
+test -f "$BOOK_PATH" && echo "FILE_OK" || echo "FILE_NOT_FOUND: $BOOK_PATH"
+case "${BOOK_PATH##*.}" in
+  pdf|PDF|epub|EPUB|docx|DOCX|txt|TXT|md|MD|markdown|MARKDOWN|rst|RST|adoc|ADOC|asciidoc|ASCIIDOC|html|HTML|htm|HTM|rtf|RTF|mobi|MOBI|azw|AZW|azw3|AZW3) echo "FORMAT_OK" ;;
+  *) echo "FORMAT_UNKNOWN" ;;
+esac
+```
+
+Check the file extension (`.pdf`, `.epub`, `.docx`, `.txt`, `.md`, `.markdown`, `.rst`, `.adoc`, `.html`, `.htm`, `.rtf`, `.mobi`, `.azw`, `.azw3`) or magic bytes (`%PDF` or `PK` zip header for EPUB/DOCX).
+
+If the file is not found or the format is not supported, stop with a clear error message listing supported formats.
+
+---
+
+## Step 1.5 — Identify book type
+
+Before extracting, ask the user:
+
+> "What kind of content does this book have? This helps me choose the best extraction method.
+>
+> 1. **Technical** — has code blocks, tables, formulas, diagrams (e.g. programming books, academic papers, architecture guides)
+> 2. **Text-heavy** — mostly prose, few or no tables/code (e.g. management, productivity, narrative non-fiction)
+> 3. **Not sure** — I'll use the fast method and warn you if quality seems limited"
+
+Store the answer as `BOOK_TYPE`:
+- Option 1 → `BOOK_TYPE=technical`
+- Option 2 → `BOOK_TYPE=text`
+- Option 3 → `BOOK_TYPE=text`
+
+**If `BOOK_TYPE=technical`**, inform the user before proceeding:
+> "📐 Technical mode selected — using Docling for structure-aware extraction (tables, code blocks, formulas preserved as markdown). This takes ~1.5s per page, so expect a few minutes for longer books. Starting now…"
+
+**If `BOOK_TYPE=text`**, inform:
+> "📄 Text mode selected — using the fastest suitable extractor for this file type. Plain text/Markdown/HTML are usually ready in seconds; PDFs use pdftotext when available."
+
+---
+
+## Step 2 — Extract text from the source document
+
+Run the extraction script, passing the book type:
+
+```bash
+SCRIPT_PATH="{baseDir}/scripts/extract.py"
+
+if [ ! -f "$SCRIPT_PATH" ]; then
+  echo "Could not find scripts/extract.py for book-to-skill" >&2
+  exit 1
+fi
+
+PYTHON_BIN="${PYTHON_BIN:-python3}"
+if ! command -v "$PYTHON_BIN" >/dev/null 2>&1; then
+  PYTHON_BIN="python"
+fi
+
+"$PYTHON_BIN" "$SCRIPT_PATH" "$BOOK_PATH" --mode <BOOK_TYPE> --install-missing ask
+```
+
+Before extraction, the script checks optional Python packages needed for the detected format. If a better extractor is missing, it prompts the user with the available fallback, for example:
+
+> "DOCX extraction uses python-docx if installed, otherwise a stdlib ZIP/XML parser. Missing package(s) detected. Do you want to install? y=install, n=fallback"
+
+Use `--install-missing yes` to install missing Python packages without prompting, `--install-missing no` or `--no-install-missing` to always use fallbacks, or `BOOK_SKILL_INSTALL_MISSING=yes|no|ask` to set the behavior by environment variable. Non-interactive sessions default to fallback unless install mode is explicitly `yes`.
+
+- PDF `--mode technical` → uses Docling (layout-aware, preserves tables and code blocks as markdown)
+- PDF `--mode text` → uses pdftotext → PyPDF2 → pdfminer fallback chain (fast, plain text)
+- EPUB → uses ebooklib + BeautifulSoup4, then stdlib ZIP/HTML fallback
+- DOCX → uses python-docx, then stdlib ZIP/XML fallback
+- TXT/Markdown/reStructuredText/AsciiDoc → reads directly as text
+- HTML → uses BeautifulSoup4, then stdlib HTML fallback
+- RTF → uses striprtf, then a basic regex fallback
+- MOBI/AZW/AZW3 → uses Calibre `ebook-convert` when installed. Calibre is an external app, not a pip package, so the script reports how to install it if missing.
+
+This creates:
+- `/book_skill_work/full_text.txt` — full extracted text
+- `/book_skill_work/metadata.json` — title, estimated pages, token count, size, extraction_mode
+
+Read the `output_text` path in `/book_skill_work/metadata.json` to understand what was extracted. The extractor uses the platform temp directory by default and supports `BOOK_SKILL_WORKDIR` if an explicit work directory is needed.
+
+---
+
+## Step 2.5 — Pre-flight cost estimate
+
+Read `/book_skill_work/metadata.json` and present the user with an estimate **before doing any generation**:
+
+```
+📖 Source detected: <filename> (<format>)
+📄 Pages/Spine items/Sections: ~<N> | Words: ~<N> | Source tokens: ~<N>K
+
+💰 Estimated token cost (Full Conversion):
+   Input  (book reading + prompts): ~<N>K tokens
+   Output (skill files generated):  ~<N>K tokens
+   Total:                           ~<N>K tokens
+
+   Reference prices (as of 2025):
+   Claude Sonnet 4.5 → ~$<X> USD
+   Claude Haiku 4.5  → ~$<X> USD
+
+   ⏱  Estimated time: ~<N> minutes
+
+📁 Files to be generated:
+   SKILL.md + <N> chapter files + glossary + patterns + cheatsheet
+
+➡  Proceed with Full Conversion? (or type "analyze only" to preview first)
+```
+
+**How to estimate:**
+- Input tokens ≈ `estimated_tokens` from metadata × 1.3 (prompts overhead per chapter pass)
+- Output tokens ≈ chapters × 1,000 + 4,000 (SKILL.md) + 4,500 (glossary + patterns + cheatsheet)
+- Price: Sonnet input=$3/MTok output=$15/MTok — Haiku input=$0.80/MTok output=$4/MTok
+
+Wait for the user to confirm before proceeding. If they say "analyze only", switch to Mode 2.
+
+---
+
+## Step 2.6 — REPL-style access for large books (> 50k tokens)
+
+Inspired by the Recursive Language Model (RLM) paradigm: treat `full_text.txt` as a queryable corpus, not a single read. Loading the whole file into context burns budget you will need later for generation.
+
+For books over ~50k tokens, prefer programmatic probes over `Read(full_text.txt)` without bounds:
+
+```bash
+# Size check before any Read
+wc -w "$FULL_TEXT_PATH"
+
+# Find chapter offsets without loading the whole file
+grep -n -E "^\s*(Chapter|CHAPTER)\s+[0-9]+" "$FULL_TEXT_PATH" | head -40
+
+# Pull only the chapter you need (lines start..end inclusive)
+sed -n '<start>,<end>p' "$FULL_TEXT_PATH"
+
+# Verify a framework is actually mentioned before claiming it in SKILL.md
+grep -c -i "westrum\|dora" "$FULL_TEXT_PATH"
+
+# Targeted Read with offset/limit avoids dumping the full file
+# Read(file_path=full_text.txt, offset=<line>, limit=<lines>)
+```
+
+Use this approach for Step 3 (structure analysis), Step 7 (per-chapter summaries), and Step 8 (glossary / patterns extraction). On books under 50k tokens, a single `Read` is fine.
+
+Why this matters: a 200-page book is ~75k tokens. Re-reading it once per chapter (28 passes) costs ~2M input tokens; using grep + sed to pull only relevant slices keeps generation cost proportional to the output, not the source.
+
+---
+
+## Step 3 — Analyze book structure
+
+Read the first 8,000 characters of the extracted `full_text.txt` to identify:
+- Book **title** and **author(s)**
+- **Chapter structure** (look for "Chapter N", "PART I", numbered headings, table of contents)
+- **Core themes** and subject domain
+- Approximate number of chapters
+
+Then read the Table of Contents section if present to map all chapters.
+
+**If mode is "Analyze Only":** produce the extraction report now and stop. Structure:
+```
+## Extraction Report — <Title>
+
+### Author's Core Frameworks
+- **<Framework Name>**: <what it is and when to apply>
+
+### Key Principles
+- <Principle>: <actionable rule>
+
+### Techniques & Methods
+- <Technique>: <step-by-step or how-to>
+
+### Anti-patterns
+- <What to avoid>: <why>
+
+### Suggested Skill Name
+`{author-lastname}-{core-concept}` — e.g. `cialdini-influence`
+
+### Chapters Detected
+| # | Title | Main Frameworks |
+```
+
+---
+
+## Step 4 — Ask purpose (Full Conversion only)
+
+Before generating, ask the user:
+
+> "What should this skill help you do? (Pick one or more)
+> 1. Apply the author's frameworks while working
+> 2. Think with the author's mental models
+> 3. Reference specific chapters and concepts
+> 4. All of the above"
+
+Use the answer to weight what gets highlighted in the SKILL.md Core section.
+
+---
+
+## Step 5 — Determine skill name
+
+If `SKILL_NAME` was provided, use it as the skill slug.
+Otherwise, propose two options and let the user choose:
+- **By author-concept**: `{author-lastname}-{core-concept}` (e.g. `cialdini-influence`, `meadows-systems`)
+- **By title**: lowercase hyphens from book title (e.g. `designing-data-intensive-apps`)
+
+Default to author-concept format if the book has a strong methodological identity.
+
+Choose the destination skill root:
+- **Amp default**: `~/.config/agents/skills`
+- **Amp project-local**: `.agents/skills` when the user explicitly wants the generated book skill scoped to the current workspace
+- **Amp legacy**: `~/.config/amp/skills` if that is the user's existing global skill location
+- **Claude Code**: `~/.claude/skills` if the user explicitly asks for Claude Code output
+
+Set `SKILLS_HOME` to the selected root and check that `$SKILLS_HOME/<skill_name>/` does NOT already exist.
+If it does, append `-2` or ask the user before overwriting.
+
+---
+
+## Step 6 — Create skill directory structure
+
+```bash
+mkdir -p "$SKILLS_HOME/<skill_name>/chapters"
+```
+
+---
+
+## Step 7 — Generate chapter summaries
+
+**TOKEN BUDGET RULE — CRITICAL:**
+- Each chapter summary file: **800–1,200 tokens** (dense, not verbose)
+- Files are loaded on-demand — they are NOT capped per se, but keep them useful and tight
+
+For EACH chapter/major section identified in Step 3:
+
+Read the corresponding section of the extracted `full_text.txt` (use character offsets or grep for chapter headings).
+
+Create `$SKILLS_HOME/<skill_name>/chapters/ch<N>-<slug>.md` using the structure below.
+
+**Adapt emphasis based on `BOOK_TYPE`:**
+- `technical` → prioritize "Code Examples", "Reference Tables", and "Commands & APIs" sections; preserve exact syntax
+- `text` → prioritize "Frameworks Introduced", "Mental Models", and "Key Takeaways"; skip empty technical sections
+
+```markdown
+# Chapter N: <Full Title>
+
+## Core Idea
+<1–2 sentences: the single most important thing this chapter teaches>
+
+## Frameworks Introduced
+- **<Framework Name>**: <exact formulation — preserve the author's naming>
+  - When to use: <specific situation>
+  - How: <steps or criteria>
+
+## Key Concepts
+- **<Term>**: <precise definition in 1 sentence>
+(5–10 most important terms from this chapter)
+
+## Mental Models
+<2–4 frameworks or thinking tools. Write as "Use X when Y" or "Think of X as Y">
+
+## Anti-patterns
+- **<What to avoid>**: <why it fails>
+
+## Code Examples *(technical books only — omit if BOOK_TYPE=text)*
+<!-- Copy the most instructive snippet from the chapter. Preserve indentation exactly. -->
+```<language>
+<key code example from this chapter>
+```
+- **What it demonstrates**: 
+
+## Reference Tables *(technical books only — omit if BOOK_TYPE=text)*
+ 
+
+## Key Takeaways
+1. 
+2. 
+3. 
+(3–7 takeaways a practitioner must remember)
+
+## Connects To
+- **Ch N**: 
+- **Ch N**: 
+```
+
+---
+
+## Step 8 — Generate supporting files
+
+### glossary.md
+Create `$SKILLS_HOME/<skill_name>/glossary.md`:
+- Every significant term from the book, alphabetically sorted
+- Format: `**Term** — definition (Ch N)`
+- Max 1,500 tokens
+
+### patterns.md
+Create `$SKILLS_HOME/<skill_name>/patterns.md`:
+- All concrete techniques, design patterns, algorithms from the book
+- Format: `## Pattern Name\n**When to use**: ...\n**How**: ...\n**Trade-offs**: ...`
+- Max 2,000 tokens
+
+### cheatsheet.md
+Create `$SKILLS_HOME/<skill_name>/cheatsheet.md`:
+- Decision tables, comparison matrices, quick-reference rules
+- The content you'd want on a single printed page
+- Max 1,000 tokens
+
+---
+
+## Step 9 — Generate the master SKILL.md
+
+**CRITICAL TOKEN BUDGET: Keep SKILL.md body under 4,000 tokens.**
+Compaction truncates from the END — put the most important content FIRST.
+
+Create `$SKILLS_HOME/<skill_name>/SKILL.md`:
+
+```markdown
+---
+name: <skill_name>
+description: "Knowledge base from \"<Full Title>\" by <Author(s)>. Use when applying <author>'s frameworks for <key topics, 3–6 terms>, studying the book, or referencing its concepts."
+allowed-tools:
+  - Read
+  - Grep
+argument-hint: [topic, framework name, or chapter number]
+---
+
+# <Full Title>
+**Author**: <Author(s)> | **Pages**: ~<N> | **Chapters**: <N> | **Generated**: <YYYY-MM-DD>
+
+## How to Use This Skill
+
+- **Without arguments** — load core frameworks for reference
+- **With a topic** — ask about `replication`, `pricing`, or another indexed topic; I find and read the relevant chapter
+- **With chapter** — ask for `ch05`; I load that specific chapter
+- **Browse** — ask "what chapters do you have?" to see the full index
+
+When you ask about a topic not covered in Core Frameworks below, I will read
+the relevant chapter file before answering.
+
+---
+
+## Core Frameworks & Mental Models
+<!-- ~2,000 tokens: the author's most important named frameworks and principles.
+     Preserve exact names. Write as "Use X when Y", "Prefer X over Y because Z".
+     This is a toolkit, not a summary. -->
+
+<generate 2,000 tokens of the most critical frameworks and insights here>
+
+---
+
+## Chapter Index
+
+| # | Title | Key Frameworks |
+|---|-------|----------------|
+| [ch01](chapters/ch01-<slug>.md) | <Title> | <framework1>, <framework2> |
+| [ch02](chapters/ch02-<slug>.md) | <Title> | <framework1>, <framework2> |
+...
+
+## Topic Index
+
+<!-- Alphabetical. Major terms/frameworks → chapter(s) that cover them. -->
+- **<Term>** → ch<N>[, ch<N>]
+- **<Term>** → ch<N>
+
+## Supporting Files
+
+- [glossary.md](glossary.md) — all key terms with definitions
+- [patterns.md](patterns.md) — all techniques and design patterns
+- [cheatsheet.md](cheatsheet.md) — quick reference tables and decision guides
+
+---
+
+## Scope & Limits
+
+This skill covers the book content only. For hands-on implementation in your codebase,
+combine with project-specific tools. For topics beyond this book, check related skills
+or ask the agent directly.
+```
+
+---
+
+## Step 10 — Cleanup and report
+
+```bash
+PYTHON_BIN="${PYTHON_BIN:-python3}"
+if ! command -v "$PYTHON_BIN" >/dev/null 2>&1; then
+  PYTHON_BIN="python"
+fi
+
+"$PYTHON_BIN" - <<'PY'
+import os
+import shutil
+import tempfile
+from pathlib import Path
+shutil.rmtree(
+    os.environ.get("BOOK_SKILL_WORKDIR", Path(tempfile.gettempdir()) / "book_skill_work"),
+    ignore_errors=True,
+)
+PY
+```
+
+Then report to the user:
+
+```
+✅ Skill created: $SKILLS_HOME/<skill_name>/
+
+📚 Book: <Full Title> — <Author>
+📄 Pages: ~<N> | Chapters: <N>
+
+Files generated:
+  SKILL.md         — core frameworks + index   (~X tokens)
+  chapters/        — <N> chapter summaries     (~X tokens each, ~X total)
+  glossary.md      — key terms                 (~X tokens)
+  patterns.md      — techniques & patterns     (~X tokens)
+  cheatsheet.md    — quick reference           (~X tokens)
+  ─────────────────────────────────────────────────────
+  Total skill size: ~X tokens (loaded on-demand, not all at once)
+
+💡 Tip: check your agent's session cost/usage command to see actual token usage.
+
+Usage:
+  Ask for <skill_name>                  → load core frameworks
+  Ask <skill_name> about <topic>        → find and explain a topic
+  Ask <skill_name> for ch<N>            → dive into a specific chapter
+```
+
+---
+
+## Quality Rules
+
+1. **Extract structure, not summaries** — capture named frameworks, exact formulations, anti-patterns; not chapter recaps
+2. **Preserve the author's precision** — "The 5 Whys" ≠ "ask why multiple times"; keep exact naming
+3. **Density over completeness** — a 1,000-token summary beats a 10,000-token excerpt
+4. **Practitioner voice** — write "Use X when Y", not "The book explains X"
+5. **Front-load SKILL.md** — compaction keeps the first 5,000 tokens; most important content comes first
+6. **Chapter files are on-demand** — they don't count against skill budget until loaded
+7. **Never copy raw book text** — always synthesize, summarize, extract signal
+8. **Topic index is critical** — it's how the agent navigates to the right chapter file

--- a/book-to-skill/scripts/extract.py
+++ b/book-to-skill/scripts/extract.py
@@ -1,0 +1,438 @@
+#!/usr/bin/env python3
+"""
+Book-to-Skill Text Extractor
+
+Extracts text from various document formats (PDF, EPUB, DOCX, HTML, Markdown, etc.)
+with optional structure-aware extraction for technical documents.
+
+Usage:
+    python extract.py <book_path> --mode <technical|text> --install-missing <ask|yes|no>
+"""
+
+import argparse
+import json
+import os
+import re
+import shutil
+import sys
+import tempfile
+import zipfile
+from pathlib import Path
+from typing import Dict, List, Optional, Tuple
+
+# Optional imports - will be imported on-demand based on format
+def try_import(module_name: str, install_name: Optional[str] = None) -> Optional[object]:
+    """Try to import a module, return None if not available."""
+    try:
+        return __import__(module_name, fromlist=[''])
+    except ImportError:
+        return None
+
+def check_install_missing(module_name: str, install_name: Optional[str] = None, 
+                          install_mode: str = 'ask') -> bool:
+    """Check if module is installed, optionally prompt to install."""
+    if try_import(module_name):
+        return True
+    
+    if install_mode == 'no':
+        return False
+    
+    install_name = install_name or module_name
+    if install_mode == 'ask':
+        response = input(f"{module_name} not installed. Install now? (y/n): ").strip().lower()
+        if response != 'y':
+            return False
+    
+    # Try to install
+    import subprocess
+    try:
+        subprocess.check_call([sys.executable, '-m', 'pip', 'install', install_name, '-q'])
+        # Clear the import cache
+        if module_name in sys.modules:
+            del sys.modules[module_name]
+        return try_import(module_name) is not None
+    except subprocess.CalledProcessError:
+        print(f"Warning: Failed to install {install_name}", file=sys.stderr)
+        return False
+
+def get_work_dir() -> Path:
+    """Get the working directory for extraction output."""
+    workdir = os.environ.get('BOOK_SKILL_WORKDIR')
+    if workdir:
+        path = Path(workdir)
+    else:
+        path = Path(tempfile.gettempdir()) / 'book_skill_work'
+    path.mkdir(parents=True, exist_ok=True)
+    return path
+
+def estimate_tokens(text: str) -> int:
+    """Estimate token count from text (rough approximation: 1 token ≈ 4 chars)."""
+    return len(text) // 4
+
+def extract_pdf_pdftotext(file_path: Path) -> Tuple[str, str]:
+    """Extract text from PDF using pdftotext (fast, plain text)."""
+    import subprocess
+    try:
+        result = subprocess.run(
+            ['pdftotext', '-layout', str(file_path), '-'],
+            capture_output=True,
+            text=True,
+            timeout=60
+        )
+        if result.returncode == 0:
+            return result.stdout, 'pdftotext'
+    except (subprocess.TimeoutExpired, FileNotFoundError):
+        pass
+    return None, None
+
+def extract_pdf_pypdf2(file_path: Path) -> Tuple[str, str]:
+    """Extract text from PDF using PyPDF2."""
+    pypdf2 = try_import('PyPDF2')
+    if not pypdf2:
+        return None, None
+    
+    text_parts = []
+    try:
+        with open(file_path, 'rb') as f:
+            reader = pypdf2.PdfReader(f)
+            for page in reader.pages:
+                text = page.extract_text()
+                if text:
+                    text_parts.append(text)
+        return '\n\n'.join(text_parts), 'PyPDF2'
+    except Exception:
+        return None, None
+
+def extract_pdf_pdfminer(file_path: Path) -> Tuple[str, str]:
+    """Extract text from PDF using pdfminer.six."""
+    pdfminer = try_import('pdfminer')
+    if not pdfminer:
+        return None, None
+    
+    try:
+        from pdfminer.high_level import extract_text
+        text = extract_text(str(file_path))
+        return text, 'pdfminer.six'
+    except Exception:
+        return None, None
+
+def extract_pdf_docling(file_path: Path) -> Tuple[str, str]:
+    """Extract text from PDF using Docling (structure-aware, preserves tables/code)."""
+    docling = try_import('docling')
+    if not docling:
+        return None, None
+    
+    try:
+        from docling.document_converter import DocumentConverter
+        converter = DocumentConverter()
+        result = converter.convert(str(file_path))
+        # Convert to markdown
+        md_text = result.document.export_to_markdown()
+        return md_text, 'Docling'
+    except Exception as e:
+        print(f"Docling extraction error: {e}", file=sys.stderr)
+        return None, None
+
+def extract_pdf(file_path: Path, mode: str, install_mode: str) -> Tuple[str, str]:
+    """Extract text from PDF with mode-specific strategy."""
+    text = None
+    method = None
+    
+    if mode == 'technical':
+        # Try Docling first for structure-aware extraction
+        if check_install_missing('docling', install_mode=install_mode):
+            text, method = extract_pdf_docling(file_path)
+        if not text:
+            print("⚠️  Docling not available, falling back to text extraction", file=sys.stderr)
+    
+    # Text mode fallback chain
+    if not text:
+        text, method = extract_pdf_pdftotext(file_path)
+    if not text:
+        if check_install_missing('PyPDF2', install_mode=install_mode):
+            text, method = extract_pdf_pypdf2(file_path)
+    if not text:
+        if check_install_missing('pdfminer.six', 'pdfminer-six', install_mode=install_mode):
+            text, method = extract_pdf_pdfminer(file_path)
+    
+    if not text:
+        raise RuntimeError("No suitable PDF extractor available")
+    
+    return text, method
+
+def extract_epub(file_path: Path, install_mode: str) -> Tuple[str, str]:
+    """Extract text from EPUB file."""
+    # Try ebooklib + BeautifulSoup first
+    ebooklib = try_import('ebooklib')
+    bs4 = try_import('bs4')
+    
+    if ebooklib and bs4:
+        try:
+            from ebooklib import epub
+            from bs4 import BeautifulSoup
+            
+            book = epub.read_epub(str(file_path))
+            text_parts = []
+            
+            for item in book.get_items():
+                if item.get_type() == ebooklib.ITEM_DOCUMENT:
+                    soup = BeautifulSoup(item.get_content(), 'html.parser')
+                    text = soup.get_text(separator='\n', strip=True)
+                    if text:
+                        text_parts.append(text)
+            
+            if text_parts:
+                return '\n\n'.join(text_parts), 'ebooklib+bs4'
+        except Exception:
+            pass
+    
+    # Fallback: treat as ZIP and extract HTML
+    try:
+        text_parts = []
+        with zipfile.ZipFile(file_path, 'r') as zf:
+            for name in zf.namelist():
+                if name.endswith('.html') or name.endswith('.xhtml'):
+                    content = zf.read(name).decode('utf-8', errors='ignore')
+                    # Simple HTML tag stripping
+                    text = re.sub(r'<[^>]+>', ' ', content)
+                    text = re.sub(r'\s+', ' ', text).strip()
+                    if text:
+                        text_parts.append(text)
+        
+        if text_parts:
+            return '\n\n'.join(text_parts), 'zip+regex'
+    except Exception:
+        pass
+    
+    raise RuntimeError("No suitable EPUB extractor available")
+
+def extract_docx(file_path: Path, install_mode: str) -> Tuple[str, str]:
+    """Extract text from DOCX file."""
+    # Try python-docx first
+    docx = try_import('docx')
+    if docx:
+        try:
+            doc = docx.Document(str(file_path))
+            text_parts = [para.text for para in doc.paragraphs if para.text.strip()]
+            if text_parts:
+                return '\n\n'.join(text_parts), 'python-docx'
+        except Exception:
+            pass
+    
+    # Fallback: treat as ZIP and extract XML
+    try:
+        text_parts = []
+        with zipfile.ZipFile(file_path, 'r') as zf:
+            if 'word/document.xml' in zf.namelist():
+                content = zf.read('word/document.xml').decode('utf-8', errors='ignore')
+                # Extract text from XML
+                text = re.sub(r'<[^>]+>', ' ', content)
+                text = re.sub(r'\s+', ' ', text).strip()
+                if text:
+                    return text, 'zip+xml'
+    except Exception:
+        pass
+    
+    raise RuntimeError("No suitable DOCX extractor available")
+
+def extract_html(file_path: Path, install_mode: str) -> Tuple[str, str]:
+    """Extract text from HTML file."""
+    bs4 = try_import('bs4')
+    if bs4:
+        try:
+            from bs4 import BeautifulSoup
+            with open(file_path, 'r', encoding='utf-8', errors='ignore') as f:
+                soup = BeautifulSoup(f.read(), 'html.parser')
+                # Remove script and style
+                for tag in soup(['script', 'style']):
+                    tag.decompose()
+                text = soup.get_text(separator='\n', strip=True)
+                return text, 'BeautifulSoup'
+        except Exception:
+            pass
+    
+    # Fallback: simple regex
+    try:
+        with open(file_path, 'r', encoding='utf-8', errors='ignore') as f:
+            content = f.read()
+            text = re.sub(r'<[^>]+>', ' ', content)
+            text = re.sub(r'\s+', ' ', text).strip()
+            return text, 'regex'
+    except Exception:
+        raise RuntimeError("No suitable HTML extractor available")
+
+def extract_rtf(file_path: Path, install_mode: str) -> Tuple[str, str]:
+    """Extract text from RTF file."""
+    striprtf = try_import('striprtf')
+    if striprtf:
+        try:
+            from striprtf.striprtf import rtf_to_text
+            with open(file_path, 'r', encoding='utf-8', errors='ignore') as f:
+                rtf_content = f.read()
+                text = rtf_to_text(rtf_content)
+                return text, 'striprtf'
+        except Exception:
+            pass
+    
+    # Fallback: basic regex (very limited)
+    try:
+        with open(file_path, 'r', encoding='utf-8', errors='ignore') as f:
+            content = f.read()
+            # Remove RTF control sequences
+            text = re.sub(r'\\[a-z]+\d?\s?', ' ', content)
+            text = re.sub(r'[{}]', ' ', text)
+            text = re.sub(r'\s+', ' ', text).strip()
+            return text, 'regex (limited)'
+    except Exception:
+        raise RuntimeError("No suitable RTF extractor available")
+
+def extract_mobi_azw(file_path: Path, install_mode: str) -> Tuple[str, str]:
+    """Extract text from MOBI/AZW files using Calibre."""
+    import subprocess
+    
+    # Check for Calibre's ebook-convert
+    try:
+        result = subprocess.run(['ebook-convert', '--version'], 
+                              capture_output=True, text=True)
+        if result.returncode != 0:
+            raise FileNotFoundError("Calibre not installed")
+    except FileNotFoundError:
+        if install_mode == 'ask':
+            print("⚠️  Calibre (ebook-convert) is required for MOBI/AZW extraction.")
+            print("   Install from: https://calibre-ebook.com/download")
+            print("   Or use: sudo apt install calibre (Linux) / brew install calibre (macOS)")
+            response = input("   Continue anyway? (y/n): ").strip().lower()
+            if response != 'y':
+                sys.exit(1)
+        elif install_mode == 'yes':
+            print("⚠️  Calibre must be installed manually. See: https://calibre-ebook.com/download")
+        raise RuntimeError("Calibre ebook-convert not available")
+    
+    # Convert to text via temporary file
+    work_dir = get_work_dir()
+    temp_txt = work_dir / 'temp_mobi.txt'
+    
+    try:
+        result = subprocess.run(
+            ['ebook-convert', str(file_path), str(temp_txt)],
+            capture_output=True,
+            text=True,
+            timeout=120
+        )
+        if result.returncode == 0 and temp_txt.exists():
+            text = temp_txt.read_text(encoding='utf-8', errors='ignore')
+            temp_txt.unlink()
+            return text, 'Calibre'
+    except subprocess.TimeoutExpired:
+        pass
+    
+    raise RuntimeError("Calibre conversion failed")
+
+def extract_text_file(file_path: Path) -> Tuple[str, str]:
+    """Read plain text files directly."""
+    encodings = ['utf-8', 'latin-1', 'cp1252']
+    for encoding in encodings:
+        try:
+            text = file_path.read_text(encoding=encoding)
+            return text, f'native ({encoding})'
+        except UnicodeDecodeError:
+            continue
+    raise RuntimeError("Could not decode text file")
+
+def extract_document(file_path: Path, mode: str, install_mode: str) -> Tuple[str, str, Dict]:
+    """
+    Extract text from a document based on its format.
+    
+    Returns:
+        Tuple of (text, extraction_method, metadata)
+    """
+    ext = file_path.suffix.lower().lstrip('.')
+    
+    # Map extensions to extractors
+    extractors = {
+        'pdf': lambda: extract_pdf(file_path, mode, install_mode),
+        'epub': lambda: extract_epub(file_path, install_mode),
+        'docx': lambda: extract_docx(file_path, install_mode),
+        'html': lambda: extract_html(file_path, install_mode),
+        'htm': lambda: extract_html(file_path, install_mode),
+        'txt': lambda: (extract_text_file(file_path)),
+        'md': lambda: (extract_text_file(file_path)),
+        'markdown': lambda: (extract_text_file(file_path)),
+        'rst': lambda: (extract_text_file(file_path)),
+        'adoc': lambda: (extract_text_file(file_path)),
+        'asciidoc': lambda: (extract_text_file(file_path)),
+        'rtf': lambda: extract_rtf(file_path, install_mode),
+        'mobi': lambda: extract_mobi_azw(file_path, install_mode),
+        'azw': lambda: extract_mobi_azw(file_path, install_mode),
+        'azw3': lambda: extract_mobi_azw(file_path, install_mode),
+    }
+    
+    if ext not in extractors:
+        raise ValueError(f"Unsupported format: .{ext}")
+    
+    # Extract
+    text, method = extractors[ext]()
+    
+    # Build metadata
+    metadata = {
+        'source_file': str(file_path),
+        'format': ext,
+        'extraction_method': method,
+        'mode': mode,
+        'file_size_bytes': file_path.stat().st_size,
+        'word_count': len(text.split()),
+        'estimated_tokens': estimate_tokens(text),
+    }
+    
+    # Estimate pages (rough: 250-300 words per page)
+    metadata['estimated_pages'] = max(1, metadata['word_count'] // 275)
+    
+    return text, method, metadata
+
+def main():
+    parser = argparse.ArgumentParser(description='Extract text from documents for book-to-skill')
+    parser.add_argument('book_path', type=str, help='Path to the book/document')
+    parser.add_argument('--mode', type=str, choices=['technical', 'text'], 
+                       default='text', help='Extraction mode')
+    parser.add_argument('--install-missing', type=str, choices=['ask', 'yes', 'no'],
+                       default='ask', help='Whether to install missing packages')
+    
+    args = parser.parse_args()
+    
+    # Validate input
+    book_path = Path(args.book_path)
+    if not book_path.exists():
+        print(f"Error: File not found: {book_path}", file=sys.stderr)
+        sys.exit(1)
+    
+    print(f"📖 Extracting: {book_path.name}")
+    print(f"   Mode: {args.mode}")
+    print(f"   Install missing: {args.install_missing}")
+    
+    try:
+        # Extract text
+        text, method, metadata = extract_document(book_path, args.mode, args.install_missing)
+        
+        # Write output
+        work_dir = get_work_dir()
+        output_path = work_dir / 'full_text.txt'
+        output_path.write_text(text, encoding='utf-8')
+        metadata['output_text'] = str(output_path)
+        
+        metadata_path = work_dir / 'metadata.json'
+        metadata_path.write_text(json.dumps(metadata, indent=2), encoding='utf-8')
+        
+        # Report
+        print(f"\n✅ Extraction complete!")
+        print(f"   Method: {method}")
+        print(f"   Output: {output_path}")
+        print(f"   Words: ~{metadata['word_count']:,}")
+        print(f"   Estimated pages: ~{metadata['estimated_pages']}")
+        print(f"   Estimated tokens: ~{metadata['estimated_tokens']:,}")
+        
+    except Exception as e:
+        print(f"\n❌ Extraction failed: {e}", file=sys.stderr)
+        sys.exit(1)
+
+if __name__ == '__main__':
+    main()

--- a/book-to-skill/scripts/submit-pr.sh
+++ b/book-to-skill/scripts/submit-pr.sh
@@ -1,0 +1,106 @@
+#!/bin/bash
+# Submit book-to-skill to the pi-skills repository
+# Usage: ./submit-pr.sh [pi-skills-repo-path]
+
+set -e
+
+PI_SKILLS_REPO="${1:-$HOME/projects/pi-skills}"
+SKILL_NAME="book-to-skill"
+SKILL_SOURCE="$HOME/.pi/agent/skills/$SKILL_NAME"
+
+echo "📚 Submitting $SKILL_NAME to pi-skills repository"
+echo ""
+
+# Check if source exists
+if [ ! -d "$SKILL_SOURCE" ]; then
+    echo "❌ Skill not found at: $SKILL_SOURCE"
+    exit 1
+fi
+
+# Check if pi-skills repo exists
+if [ ! -d "$PI_SKILLS_REPO" ]; then
+    echo "📥 Cloning pi-skills repository..."
+    git clone https://github.com/badlogic/pi-skills "$PI_SKILLS_REPO"
+fi
+
+cd "$PI_SKILLS_REPO"
+
+# Check for uncommitted changes
+if [ -n "$(git status --porcelain)" ]; then
+    echo "⚠️  Uncommitted changes in pi-skills repo. Please commit or stash them."
+    exit 1
+fi
+
+# Create feature branch
+BRANCH_NAME="feature/add-$SKILL_NAME"
+echo "🌿 Creating branch: $BRANCH_NAME"
+git checkout -b "$BRANCH_NAME" 2>/dev/null || git checkout "$BRANCH_NAME"
+
+# Copy skill files
+echo "📁 Copying skill files..."
+rm -rf "$PI_SKILLS_REPO/$SKILL_NAME"
+cp -r "$SKILL_SOURCE" "$PI_SKILLS_REPO/$SKILL_NAME"
+
+# Show what will be committed
+echo ""
+echo "📋 Files to commit:"
+git status --short
+
+# Stage the skill
+git add "$SKILL_NAME/"
+
+# Commit
+echo ""
+echo "💾 Creating commit..."
+git commit -m "Add $SKILL_NAME: Convert books/documents into agent skills
+
+- Supports PDF, EPUB, DOCX, HTML, Markdown, TXT, RTF, MOBI/AZW
+- Extracts frameworks, mental models, principles, and techniques
+- Creates structured skills with chapters, glossary, patterns, cheatsheet
+- Cost-optimized for large books (>50k tokens)
+- Compatible with pi, Claude Code, Amp, and Droid
+
+License: MIT
+"
+
+echo ""
+echo "✅ Commit created successfully!"
+echo ""
+echo "📤 To push and create PR, run:"
+echo ""
+echo "   cd $PI_SKILLS_REPO"
+echo "   git push -u origin $BRANCH_NAME"
+echo ""
+echo "   Then open a PR at:"
+echo "   https://github.com/badlogic/pi-skills/compare/$BRANCH_NAME?expand=1"
+echo ""
+echo "📝 PR Description Template:"
+echo "━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━"
+cat << 'TEMPLATE'
+## book-to-skill
+
+A skill that converts books and documents into structured agent skills.
+
+### Features
+
+- **Multi-format support**: PDF, EPUB, DOCX, HTML, Markdown, TXT, RTF, MOBI/AZW
+- **Structure-aware extraction**: Preserves tables, code blocks, and formulas (technical mode)
+- **Cost-optimized**: Uses REPL-style access for large books (>50k tokens)
+- **Complete output**: Generates SKILL.md, chapter summaries, glossary, patterns, and cheatsheet
+- **Agent-agnostic**: Compatible with pi, Claude Code, Amp, and Droid
+
+### Requirements
+
+- Python 3.6+
+- Optional: `PyPDF2`, `python-docx`, `ebooklib`, `beautifulsoup4`, `docling`
+- Optional: Calibre (for MOBI/AZW formats)
+
+### Files Added
+
+- `book-to-skill/SKILL.md` - Main skill definition
+- `book-to-skill/README.md` - Documentation
+- `book-to-skill/LICENSE` - MIT license
+- `book-to-skill/scripts/extract.py` - Text extraction script
+TEMPLATE
+echo "━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━"
+echo ""


### PR DESCRIPTION
## book-to-skill

A skill that converts books and documents into structured agent skills.

### Features

- **Multi-format support**: PDF, EPUB, DOCX, HTML, Markdown, TXT, RTF, MOBI/AZW
- **Structure-aware extraction**: Preserves tables, code blocks, and formulas (technical mode)
- **Cost-optimized**: Uses REPL-style access for large books (>50k tokens)
- **Complete output**: Generates SKILL.md, chapter summaries, glossary, patterns, and cheatsheet
- **Agent-agnostic**: Compatible with pi, Claude Code, Amp, and Droid

### Requirements

- Python 3.6+
- Optional: `PyPDF2`, `python-docx`, `ebooklib`, `beautifulsoup4`, `docling`
- Optional: Calibre (for MOBI/AZW formats)

### Files Added

- `book-to-skill/SKILL.md` - Main skill definition
- `book-to-skill/README.md` - Documentation
- `book-to-skill/LICENSE` - MIT license
- `book-to-skill/scripts/extract.py` - Text extraction script
