### PR TITLE
fix(transcribe): avoid unbound variable error in cleanup with set -u

### DIFF
--- a/transcribe/transcribe.sh
+++ b/transcribe/transcribe.sh
@@ -29,9 +29,9 @@ URL="https://github.com/badlogic/pibot/releases/download/$VERSION/$ASSET"
 
 CLEANUP_PATHS=()
 cleanup() {
-  for path in "${CLEANUP_PATHS[@]}"; do
-    rm -rf "$path"
-  done
+  if [ ${#CLEANUP_PATHS[@]} -gt 0 ]; then
+    rm -rf "${CLEANUP_PATHS[@]}"
+  fi
 }
 trap cleanup EXIT
 


### PR DESCRIPTION
When CLEANUP_PATHS array is empty, iterating with ${CLEANUP_PATHS[@]} triggers an unbound variable error under 'set -u'. Check array length before cleanup to prevent this.