### PR TITLE
Add lark-pi-bridge: Lark/Feishu bidirectional AI bridge with auto-rep…

### DIFF
--- a/README.md
+++ b/README.md
@@ -53,6 +53,7 @@ ln -s ~/pi-skills/browser-tools ~/.claude/skills/browser-tools
 ln -s ~/pi-skills/gccli ~/.claude/skills/gccli
 ln -s ~/pi-skills/gdcli ~/.claude/skills/gdcli
 ln -s ~/pi-skills/gmcli ~/.claude/skills/gmcli
+ln -s ~/pi-skills/lark-pi-bridge ~/.claude/skills/lark-pi-bridge
 ln -s ~/pi-skills/transcribe ~/.claude/skills/transcribe
 ln -s ~/pi-skills/vscode ~/.claude/skills/vscode
 ln -s ~/pi-skills/youtube-transcript ~/.claude/skills/youtube-transcript
@@ -64,6 +65,7 @@ ln -s ~/pi-skills/browser-tools .claude/skills/browser-tools
 ln -s ~/pi-skills/gccli .claude/skills/gccli
 ln -s ~/pi-skills/gdcli .claude/skills/gdcli
 ln -s ~/pi-skills/gmcli .claude/skills/gmcli
+ln -s ~/pi-skills/lark-pi-bridge .claude/skills/lark-pi-bridge
 ln -s ~/pi-skills/transcribe .claude/skills/transcribe
 ln -s ~/pi-skills/vscode .claude/skills/vscode
 ln -s ~/pi-skills/youtube-transcript .claude/skills/youtube-transcript
@@ -78,6 +80,7 @@ ln -s ~/pi-skills/youtube-transcript .claude/skills/youtube-transcript
 | [gccli](gccli/SKILL.md) | Google Calendar CLI for events and availability |
 | [gdcli](gdcli/SKILL.md) | Google Drive CLI for file management and sharing |
 | [gmcli](gmcli/SKILL.md) | Gmail CLI for email, drafts, and labels |
+| [lark-pi-bridge](lark-pi-bridge/SKILL.md) | Lark/Feishu bidirectional bridge with auto-reply and pi agent integration |
 | [transcribe](transcribe/SKILL.md) | Speech-to-text transcription via Groq Whisper API |
 | [vscode](vscode/SKILL.md) | VS Code integration for diffs and file comparison |
 | [youtube-transcript](youtube-transcript/SKILL.md) | Fetch YouTube video transcripts |
@@ -108,6 +111,7 @@ Some skills require additional setup. Generally, the agent will walk you through
 - **browser-tools**: Requires Chrome and Node.js. Run `npm install` in the skill directory.
 - **gccli**: Requires Node.js. Install globally with `npm install -g @mariozechner/gccli`.
 - **gdcli**: Requires Node.js. Install globally with `npm install -g @mariozechner/gdcli`.
+- **lark-pi-bridge**: Requires [lark-cli](https://github.com/neuters/lark-cli). Install with `brew install neuters/tap/lark-cli`.
 - **gmcli**: Requires Node.js. Install globally with `npm install -g @mariozechner/gmcli`.
 - **subagent**: Requires pi-coding-agent. Install globally with `npm install -g @mariozechner/pi-coding-agent`.
 - **transcribe**: Requires curl and a Groq API key.

--- a/lark-pi-bridge/LICENSE
+++ b/lark-pi-bridge/LICENSE
@@ -1,0 +1,21 @@
+MIT License
+
+Copyright (c) 2026 Yin Minghua
+
+Permission is hereby granted, free of charge, to any person obtaining a copy
+of this software and associated documentation files (the "Software"), to deal
+in the Software without restriction, including without limitation the rights
+to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+copies of the Software, and to permit persons to whom the Software is
+furnished to do so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in all
+copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+SOFTWARE.

--- a/lark-pi-bridge/README.md
+++ b/lark-pi-bridge/README.md
@@ -1,0 +1,132 @@
+# lark-pi-bridge
+
+> Lark(飞书) ↔ AI Agent 双向桥接。自动接收飞书消息、调用 AI 回复、支持工具调用。
+
+[![Agent Skills](https://img.shields.io/badge/Agent%20Skills-compatible-brightgreen)](https://agentskills.io)
+[![License: MIT](https://img.shields.io/badge/License-MIT-yellow.svg)](LICENSE)
+
+## 功能
+
+- **自动回复守护进程** — 监听飞书 IM 消息，自动调用 AI 回复（支持上下文记忆）
+- **交互模式** — AI Agent 主动轮询消息，使用完整工具箱回复（搜索、浏览器、文档等）
+- **零配置 API** — 自动读取 pi 的 `models.json` 配置，无需硬编码密钥
+- **开机自启** — 通过 launchd 在 macOS 登录时自动启动
+- **高兼容性** — 支持 pi、Claude Code、Codex CLI、Amp、Droid 等 Agent Skills 标准平台
+
+## 架构
+
+```
+Lark 用户 → WebSocket → lark-cli event consume
+                              ↓
+                       events.jsonl
+                      ↙         ↘
+          auto-daemon              AI Agent (pi/Claude/Codex)
+        （自动快速回复）             （交互处理 + 工具调用）
+              ↓                          ↓
+      lark-cli +messages-send    lark-cli +messages-reply
+```
+
+### 两种模式
+
+| 模式 | 描述 | 适合场景 |
+|------|------|---------|
+| **Auto-Daemon** | 守护进程自动监听并回复 | 日常聊天、快速问答、24h 在线 |
+| **Interactive** | AI Agent 轮询消息后处理 | 复杂任务、需搜索/查文档/浏览器 |
+
+两种模式可以并存：auto-daemon 处理日常对话，需要工具时由 AI Agent 接管。
+
+## 快速开始
+
+### 安装
+
+```bash
+# pi-coding-agent
+git clone https://github.com/YOUR_USERNAME/lark-pi-bridge ~/.pi/agent/skills/lark-pi-bridge
+
+# Claude Code
+git clone https://github.com/YOUR_USERNAME/lark-pi-bridge ~/.claude/skills/lark-pi-bridge
+
+# Codex CLI
+git clone https://github.com/YOUR_USERNAME/lark-pi-bridge ~/.codex/skills/lark-pi-bridge
+```
+
+### 前置条件
+
+- [lark-cli](https://www.npmjs.com/package/@larksuite/cli) — `npm install -g @larksuite/cli`
+- 飞书 Bot 应用配置（appId + appSecret）
+- Bot 身份已认证（`lark-cli auth status` 显示 bot ready）
+
+### 启动
+
+```bash
+cd ~/.pi/agent/skills/lark-pi-bridge
+scripts/bridge.sh start     # 启动全部组件
+scripts/bridge.sh status    # 查看状态
+scripts/bridge.sh stop      # 停止全部
+```
+
+### 开机自启 (macOS)
+
+```bash
+launchctl load ~/Library/LaunchAgents/com.johnwick.lark-pi-bridge.plist
+```
+
+## 数据文件
+
+所有数据存储在 `~/.pi/agent/data/lark-bridge/`：
+
+| 文件 | 说明 |
+|------|------|
+| `events.jsonl` | 飞书事件原始数据（由 lark-cli 写入） |
+| `replied.jsonl` | 已回复记录（含问题+回答，用于上下文记忆） |
+| `consumer.log` | lark-cli event consumer 日志 |
+| `daemon.log` | auto-daemon 运行日志 |
+| `manager.log` | bridge.sh 管理操作日志 |
+
+## 配置
+
+### AI 模型
+
+auto-daemon 自动使用 pi 的默认 provider 和 model（当前：sensenova / deepseek-v4-flash）。如需修改，编辑 `~/.pi/agent/settings.json`：
+
+```json
+{
+  "defaultProvider": "sensenova",
+  "defaultModel": "deepseek-v4-flash"
+}
+```
+
+### 身份
+
+| 身份 | 状态 | 能力 |
+|------|------|------|
+| Bot | ✅ | 收发消息，显示为"Bot"名义 |
+| User | 可选 | 收发消息，显示为个人身份 |
+
+User 身份配置（可选）：
+
+```bash
+lark-cli auth login --scope "im:message" --no-wait --json
+```
+
+## 兼容性
+
+| 平台 | 支持 | 备注 |
+|------|------|------|
+| pi-coding-agent | ✅ | 原生支持，SKILL.md 自动发现 |
+| Claude Code | ✅ | 兼容 Agent Skills 标准 |
+| Codex CLI | ✅ | 兼容 Agent Skills 标准 |
+| Amp | ✅ | 递归发现 SKILL.md |
+| Droid | ✅ | 兼容 Agent Skills 标准 |
+
+## 开发计划
+
+- [ ] 群聊消息支持（含 @匹配）
+- [ ] 消息富文本回复（图片、卡片）
+- [ ] 多会话上下文管理
+- [ ] 仅 Linux systemd 自启配置
+- [ ] Docker 部署支持
+
+## License
+
+MIT

--- a/lark-pi-bridge/SKILL.md
+++ b/lark-pi-bridge/SKILL.md
@@ -1,0 +1,150 @@
+---
+name: lark-pi-bridge
+description: "Lark(飞书) ↔ AI Agent 双向桥接。自动接收飞书消息并回复，支持 auto-daemon 快速回复 + 交互模式工具调用。兼容 pi、Claude Code、Codex CLI、Amp、Droid。"
+metadata:
+  requires:
+    bins: ["lark-cli"]
+  cliHelp: "lark-cli --help"
+---
+
+# Lark ↔ pi Bridge
+
+> **前置条件**: 确保 `lark-cli` 已安装（`npm install -g @larksuite/cli`），bot 身份可用（`lark-cli auth status`）
+
+## 安装
+
+### Pi
+
+```bash
+git clone <repo-url> ~/.pi/agent/skills/lark-pi-bridge
+```
+
+Pi 自动发现 skill，启动后会显示 `/lark:start`、`/lark:status` 等命令。
+
+### Claude Code / Codex CLI / Amp / Droid
+
+```bash
+# Claude Code
+git clone <repo-url> ~/.claude/skills/lark-pi-bridge
+
+# Codex CLI
+git clone <repo-url> ~/.codex/skills/lark-pi-bridge
+
+# Amp
+git clone <repo-url> ~/.config/amp/tools/lark-pi-bridge
+```
+
+## 架构
+
+```
+Lark 用户 → WebSocket → event consume (守护进程)
+                              ↓ stdout
+                      events.jsonl
+                       ↙         ↘
+           auto-daemon.sh           AI Agent（你）
+          (自动回复，快速聊天)       (交互处理，工具调用)
+                ↓                         ↓
+       lark-cli +messages-send    lark-cli +messages-reply/send
+```
+
+**数据目录**: `~/.pi/agent/data/lark-bridge/`
+
+## 两种工作模式
+
+### 模式 A：自动回复模式（auto-daemon，独立运行）
+
+守护进程自动监听飞书消息并回复。**每次登录自动启动**，Agent 不在也在线。
+
+适合：日常聊天、快速问答。使用 Agent 的默认 AI 模型（当前 deepseek-v4-flash）。
+
+### 模式 B：交互模式（Agent 在线处理）
+
+Agent 主动轮询新消息，用完整工具箱回复（可调用搜索、浏览器、Lark 文档等）。
+
+适合：复杂任务、需要工具调用、需要访问 Lark 资源。
+
+**两种模式可以共存**：auto-daemon 自动回复简单消息；Agent 通过 `/lark:check` 接管需要工具的场景。
+
+## 快速开始
+
+| 命令 | 用途 |
+|------|------|
+| `/lark:start` | 启动全部（consumer + auto-daemon） |
+| `/lark:stop` | 停止全部 |
+| `/lark:status` | 查看运行状态 |
+| `/lark:check` | 轮询未处理的新消息（交互模式） |
+| `/lark:chat` | 查看最近对话历史 |
+| `/lark:log` | 查看守护进程日志 |
+
+```bash
+# 查看状态
+scripts/bridge.sh status
+
+# 启动全部
+scripts/bridge.sh start
+
+# 检查新消息（交互模式）
+scripts/bridge.sh poll
+```
+
+## 自动回复守护进程
+
+### 特性
+
+- **从 Agent 配置读 API**: 自动使用 pi 的 `defaultProvider/defaultModel`
+- **上下文记忆**: 自动加载最近 5 条对话历史
+- **去重**: 不会重复回复同一消息
+- **稳定**: 2 秒轮询，低资源消耗
+
+### 数据
+
+```
+~/.pi/agent/data/lark-bridge/
+├── events.jsonl      ← 飞书事件原始数据
+├── replied.jsonl     ← 已回复记录（含 question + reply）
+├── consumer.log      ← event consumer 日志
+├── daemon.log        ← auto-daemon 日志
+└── manager.log       ← bridge.sh 操作日志
+```
+
+## 交互模式消息处理
+
+Agent 检查到新消息时应：
+
+1. **展示消息**: "📩 Lark 消息: {内容}"
+2. **理解并思考**: 需要工具就调用工具
+3. **回复**: `lark-cli im +messages-send --chat-id <id> --text "回复" --as bot`
+4. **记录**: 写入 replied.jsonl
+
+回复风格：自然亲切，像朋友聊天。用中文。
+
+## 响应规则
+
+- 当用户提到 Lark 消息时 → 执行 `scripts/bridge.sh poll`
+- 每次对话开始时 → 检查 `scripts/bridge.sh status` 确保桥接在线
+- 发现新消息 → 展示给用户，等待指示如何回复
+- 对于需要工具的问题 → 用 Agent 的全部能力处理
+
+## 开机自启 (macOS)
+
+```bash
+launchctl load ~/Library/LaunchAgents/com.johnwick.lark-pi-bridge.plist
+```
+
+## 身份说明
+
+- **Bot 身份** ✅: `--as bot` 收发消息，回复显示为 Bot 名义
+- **User 身份** ❌: 可选配置，显示为个人身份
+
+## 故障排查
+
+```bash
+# 检查 WebSocket 连接
+tail -3 ~/.pi/agent/data/lark-bridge/consumer.log
+
+# 检查 auto-daemon 日志
+tail -20 ~/.pi/agent/data/lark-bridge/daemon.log
+
+# 重启
+scripts/bridge.sh restart
+```

--- a/lark-pi-bridge/references/architecture.md
+++ b/lark-pi-bridge/references/architecture.md
@@ -1,0 +1,54 @@
+# lark-pi-bridge 快速参考
+
+## 架构总结
+
+```
+Lark 用户 → 发消息 → 飞书服务器 → WebSocket → lark-cli event consume (守护进程)
+                                                           ↓ stdout
+                                                    /tmp/lark-pi-bridge/events.jsonl
+                                                           ↓ 轮询
+                                                    pi agent (通过本 skill)
+                                                           ↓
+                                                    lark-cli im +messages-reply/send → 回复用户
+```
+
+## 实现原理
+
+1. **lark-cli** 是一个 Node.js CLI 工具，封装了飞书 OpenAPI
+2. 它用 `appId` + `appSecret`（Bot 身份）通过 WebSocket 订阅飞书事件
+3. `lark-cli event consume im.message.receive_v1` 启动长连接，实时接收 IM 消息
+4. 事件数据以 JSON Lines 格式输出到 stdout
+5. 本 skill 管理这个 consumer 的生命周期，并提供轮询接口
+
+## 数据流
+
+| 组件 | 写什么 | 路径 |
+|------|--------|------|
+| lark-cli consumer stdout | 事件 JSON | `/tmp/lark-pi-bridge/events.jsonl` |
+| lark-cli consumer stderr | 诊断日志 | `/tmp/lark-pi-bridge/daemon.log` |
+| bridge.sh 输出 | 操作日志 | `/tmp/lark-pi-bridge/bridge.log` |
+| replied.jsonl | 已回复记录 | `/tmp/lark-pi-bridge/replied.jsonl` |
+
+## 事件 JSON 格式
+
+```json
+{
+  "type": "im.message.receive_v1",
+  "event_id": "60dde270859e5197fd258580f097810a",
+  "message_id": "om_x100b6db8905fe0b0eeaab21a5076c5a",
+  "create_time": "1781059049211",
+  "chat_id": "oc_0ac7c769de219683d9cae2585a30deaa",
+  "chat_type": "p2p",
+  "message_type": "text",
+  "sender_id": "ou_2a060e158be6079663cccadbcace1c16",
+  "content": "消息内容（text/post/image 已解析为纯文本）"
+}
+```
+
+## 配置信息
+
+- **App ID**: `cli_aa93bec52e615e18`
+- **Bot 身份**: ✅ 可用
+- **User 身份**: ❌ 未配置（需要 `lark-cli auth login`）
+- **默认模型**: deepseek-v4-flash (Sensenova)
+- **已回复消息**: 16 条上下文在 replied.jsonl

--- a/lark-pi-bridge/references/com.lark-pi-bridge.plist
+++ b/lark-pi-bridge/references/com.lark-pi-bridge.plist
@@ -1,0 +1,35 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
+<!-- 
+  lark-pi-bridge launchd plist
+  安装: cp com.lark-pi-bridge.plist ~/Library/LaunchAgents/ && launchctl load ~/Library/LaunchAgents/com.lark-pi-bridge.plist
+  卸载: launchctl unload ~/Library/LaunchAgents/com.lark-pi-bridge.plist
+-->
+<plist version="1.0">
+<dict>
+    <key>Label</key>
+    <string>com.lark-pi-bridge</string>
+    <key>ProgramArguments</key>
+    <array>
+        <string>/Users/johnwick/.pi/agent/skills/lark-pi-bridge/scripts/bridge.sh</string>
+        <string>start</string>
+    </array>
+    <key>RunAtLoad</key>
+    <true/>
+    <key>KeepAlive</key>
+    <false/>
+    <key>StandardOutPath</key>
+    <string>/Users/johnwick/.pi/agent/data/lark-bridge/launchd.log</string>
+    <key>StandardErrorPath</key>
+    <string>/Users/johnwick/.pi/agent/data/lark-bridge/launchd.log</string>
+    <key>EnvironmentVariables</key>
+    <dict>
+        <key>PATH</key>
+        <string>/opt/homebrew/bin:/usr/local/bin:/usr/bin:/bin</string>
+        <key>HOME</key>
+        <string>/Users/johnwick</string>
+    </dict>
+    <key>UserName</key>
+    <string>johnwick</string>
+</dict>
+</plist>

--- a/lark-pi-bridge/scripts/auto-daemon.sh
+++ b/lark-pi-bridge/scripts/auto-daemon.sh
@@ -1,0 +1,241 @@
+#!/bin/bash
+# =============================================
+# lark-pi-bridge 自动回复守护进程 v4
+# 从 pi 的 models.json 读取 API 配置，无硬编码密钥
+# =============================================
+
+set -e
+
+# ---------- 路径 ----------
+DATA_DIR="$HOME/.pi/agent/data/lark-bridge"
+EVENT_LOG="$DATA_DIR/events.jsonl"
+REPLIED_FILE="$DATA_DIR/replied.jsonl"
+DAEMON_LOG="$DATA_DIR/daemon.log"
+PID_FILE="$DATA_DIR/daemon.pid"
+
+mkdir -p "$DATA_DIR"
+
+echo "$$" > "$PID_FILE"
+echo "[daemon v4] $(date '+%Y-%m-%d %H:%M:%S') START" >> "$DAEMON_LOG"
+
+# ---------- 从 pi 配置读取默认 API ----------
+read_pi_config() {
+    local cfg
+    cfg=$(python3 -c "
+import json, os
+path = os.path.expanduser('~/.pi/agent/models.json')
+with open(path) as f:
+    d = json.load(f)
+
+# 从 settings.json 读 defaultProvider/defaultModel
+settings_path = os.path.expanduser('~/.pi/agent/settings.json')
+default_provider = 'sensenova'
+default_model = 'deepseek-v4-flash'
+try:
+    with open(settings_path) as sf:
+        s = json.load(sf)
+        default_provider = s.get('defaultProvider', default_provider)
+        default_model = s.get('defaultModel', default_model)
+except: pass
+
+# 查找 provider 配置
+providers = d.get('providers', {})
+p = providers.get(default_provider, {})
+print(json.dumps({
+    'provider': default_provider,
+    'model': default_model,
+    'baseUrl': p.get('baseUrl', ''),
+    'apiKey': p.get('apiKey', ''),
+    'api': p.get('api', 'openai-completions')
+}))
+" 2>/dev/null) || echo '{"provider":"sensenova","model":"deepseek-v4-flash","baseUrl":"https://token.sensenova.cn/v1","apiKey":"","api":"openai-completions"}'
+    echo "$cfg"
+}
+
+PI_CONFIG=$(read_pi_config)
+API_KEY=$(echo "$PI_CONFIG" | python3 -c "import sys,json; print(json.load(sys.stdin)['apiKey'])" 2>/dev/null)
+API_URL=$(echo "$PI_CONFIG" | python3 -c "import sys,json; d=json.load(sys.stdin); u=d['baseUrl']; print(f'{u}/chat/completions' if u else '')" 2>/dev/null)
+MODEL=$(echo "$PI_CONFIG" | python3 -c "import sys,json; print(json.load(sys.stdin)['model'])" 2>/dev/null)
+
+[ -z "$API_KEY" ] && { echo "[daemon v4] ERROR: No API key found in pi config" >> "$DAEMON_LOG"; exit 1; }
+[ -z "$API_URL" ] && { echo "[daemon v4] ERROR: No API URL found in pi config" >> "$DAEMON_LOG"; exit 1; }
+
+echo "[daemon v4] Using: $MODEL @ $API_URL" >> "$DAEMON_LOG"
+
+# ---------- 系统提示词 ----------
+SYSTEM_PROMPT="你是 pi agent，一个智能 AI 助手，运行在 john 的电脑上，通过飞书 Bot 与 john 对话。
+
+风格：自然、亲切，像朋友聊天。用中文。简洁但不敷衍。知道自己是谁（pi agent），也知道在和谁对话（john）。
+
+当前是飞书私聊。"
+
+# ---------- 函数 ----------
+call_ai() {
+    local content="$1"
+    local context="$2"  # 可选的上下文JSON（最近5条）
+    
+    local payload
+    payload=$(python3 -c "
+import json, sys
+content = sys.argv[1]
+ctx_raw = sys.argv[2]
+model = sys.argv[3]
+
+system = '''$SYSTEM_PROMPT'''
+
+messages = [{'role': 'system', 'content': system}]
+
+# 加入上下文记忆
+if ctx_raw:
+    try:
+        ctx = json.loads(ctx_raw)
+        for item in ctx[-5:]:  # 最多5条
+            q = item.get('question', '')
+            r = item.get('reply', '')
+            if q:
+                messages.append({'role': 'user', 'content': q})
+            if r and r != '__pending__':
+                messages.append({'role': 'assistant', 'content': r})
+    except: pass
+
+messages.append({'role': 'user', 'content': content})
+
+obj = {
+    'model': model,
+    'messages': messages,
+    'max_tokens': 2048,
+    'temperature': 0.7
+}
+json.dump(obj, sys.stdout, ensure_ascii=False)
+" "$content" "${2:-}" "$MODEL" 2>/dev/null)
+    
+    [ -z "$payload" ] && { echo "ERROR: payload gen failed"; return 1; }
+    
+    local result
+    result=$(curl -s -X POST "$API_URL" \
+        -H "Authorization: Bearer $API_KEY" \
+        -H "Content-Type: application/json" \
+        -d "$payload" 2>/dev/null)
+    
+    echo "$result" | python3 -c "
+import sys, json
+try:
+    d = json.load(sys.stdin)
+    if 'choices' in d and d['choices']:
+        print(d['choices'][0]['message']['content'].strip())
+    else:
+        print('ERROR: ' + d.get('error', {}).get('message', str(d)))
+except Exception as e:
+    print('ERROR: ' + str(e))
+" 2>/dev/null
+}
+
+send_reply() {
+    lark-cli im +messages-send --chat-id "$1" --text "$2" --as bot >/dev/null 2>&1
+}
+
+load_context() {
+    python3 -c "
+import json
+try:
+    with open('$REPLIED_FILE') as f:
+        lines = [l for l in f if l.strip()]
+    items = []
+    for l in lines[-20:]:
+        d = json.loads(l)
+        if d.get('reply') and d['reply'] != '__pending__':
+            items.append(d)
+    print(json.dumps(items[-5:], ensure_ascii=False))
+except:
+    print('[]')
+" 2>/dev/null
+}
+
+record_reply() {
+    local mid="$1" question="$2" reply="$3"
+    local ts
+    ts=$(date +%s)
+    # 用临时文件避免 shell 注入
+    python3 -c "
+import json, sys, time
+mid = sys.argv[1]
+question = sys.argv[2]
+reply = sys.argv[3]
+ts = int(sys.argv[4])
+record = json.dumps({
+    'message_id': mid,
+    'question': question,
+    'reply': reply,
+    'time': ts
+}, ensure_ascii=False)
+with open('$REPLIED_FILE', 'a') as f:
+    f.write(record + '\n')
+" "$mid" "$question" "$reply" "$ts" 2>/dev/null
+}
+
+process_event() {
+    local line="$1"
+    [ -z "$line" ] && return
+    
+    local mid cid ctp mtp cnt
+    mid=$(echo "$line" | python3 -c "import sys,json; d=json.loads(sys.stdin.read()); print(d.get('message_id') or d.get('id',''))" 2>/dev/null)
+    cid=$(echo "$line" | python3 -c "import sys,json; d=json.loads(sys.stdin.read()); print(d.get('chat_id',''))" 2>/dev/null)
+    ctp=$(echo "$line" | python3 -c "import sys,json; d=json.loads(sys.stdin.read()); print(d.get('chat_type',''))" 2>/dev/null)
+    mtp=$(echo "$line" | python3 -c "import sys,json; d=json.loads(sys.stdin.read()); print(d.get('message_type',''))" 2>/dev/null)
+    cnt=$(echo "$line" | python3 -c "import sys,json; d=json.loads(sys.stdin.read()); print(d.get('content',''))" 2>/dev/null)
+    
+    [ -z "$mid" ] && return
+    [ "$ctp" != "p2p" ] && return
+    [ "$mtp" != "text" ] && return
+    
+    # 去重
+    if grep -q "$mid" "$REPLIED_FILE" 2>/dev/null; then
+        return
+    fi
+    
+    echo "[$(date +%H:%M:%S)] 📩 $cnt" >> "$DAEMON_LOG"
+    
+    # 加载上下文
+    local context
+    context=$(load_context)
+    
+    # 调用 AI
+    local reply
+    reply=$(call_ai "$cnt" "$context")
+    
+    if [ -n "$reply" ] && [[ "$reply" != ERROR* ]]; then
+        echo "[$(date +%H:%M:%S)] 💬 ${reply:0:60}..." >> "$DAEMON_LOG"
+        send_reply "$cid" "$reply"
+    else
+        echo "[$(date +%H:%M:%S)] ⚠️ $reply" >> "$DAEMON_LOG"
+        reply="收到，让我想想..."
+        send_reply "$cid" "$reply"
+    fi
+    
+    record_reply "$mid" "$cnt" "$reply"
+}
+
+# ---------- 主循环 ----------
+touch "$EVENT_LOG"
+touch "$REPLIED_FILE"
+echo "[daemon v4] READY: listening on $EVENT_LOG" >> "$DAEMON_LOG"
+
+# 用 hash 追踪文件位置
+last_size=0
+
+while true; do
+    if [ -f "$EVENT_LOG" ]; then
+        current_size=$(stat -f%z "$EVENT_LOG" 2>/dev/null)
+        
+        if [ "$current_size" -gt "$last_size" ]; then
+            # 读取新内容
+            dd bs=1 skip="$last_size" count=$((current_size - last_size)) if="$EVENT_LOG" 2>/dev/null | \
+            while IFS= read -r line; do
+                [ -z "$line" ] && continue
+                process_event "$line"
+            done
+            last_size=$current_size
+        fi
+    fi
+    sleep 2
+done

--- a/lark-pi-bridge/scripts/bridge.sh
+++ b/lark-pi-bridge/scripts/bridge.sh
@@ -1,0 +1,357 @@
+#!/bin/bash
+# lark-pi-bridge 统一管理脚本
+# 管理：event consumer + 自动回复守护进程
+
+DATA_DIR="$HOME/.pi/agent/data/lark-bridge"
+EVENT_FILE="$DATA_DIR/events.jsonl"
+REPLIED_FILE="$DATA_DIR/replied.jsonl"
+CONSUMER_PID="$DATA_DIR/consumer.pid"
+DAEMON_PID="$DATA_DIR/daemon.pid"
+CONSUMER_LOG="$DATA_DIR/consumer.log"
+DAEMON_LOG="$DATA_DIR/daemon.log"
+MANAGER_LOG="$DATA_DIR/manager.log"
+
+mkdir -p "$DATA_DIR"
+
+log() {
+    echo "[manager] $(date '+%H:%M:%S') $*" | tee -a "$MANAGER_LOG"
+}
+
+# ============ 启动全部 ============
+start() {
+    start_consumer
+    start_daemon
+    log "✅ lark-pi-bridge fully started"
+}
+
+# ============ 启动事件消费 ============
+start_consumer() {
+    if [ -f "$CONSUMER_PID" ] && kill -0 "$(cat "$CONSUMER_PID")" 2>/dev/null; then
+        log "consumer already running (pid=$(cat "$CONSUMER_PID"))"
+        return 0
+    fi
+
+    # 清理旧 consumer
+    for pid in $(pgrep -f "lark-cli event consume im.message.receive_v1" 2>/dev/null); do
+        kill "$pid" 2>/dev/null
+    done
+
+    # 启动 consumer
+    # stdout → events.jsonl（事件数据）
+    # stderr → consumer.log（诊断）
+    nohup bash -c "
+        exec < <(tail -f /dev/null)
+        lark-cli event consume im.message.receive_v1 --as bot --timeout 86400s
+    " 1>>"$EVENT_FILE" 2>>"$CONSUMER_LOG" &
+    local pid=$!
+    echo "$pid" > "$CONSUMER_PID"
+
+    # 等待 ready
+    local waited=0
+    while [ $waited -lt 15 ]; do
+        if grep -q "ready event_key" "$CONSUMER_LOG" 2>/dev/null; then
+            log "consumer started (pid=$pid) ✅"
+            return 0
+        fi
+        sleep 1
+        ((waited++))
+    done
+    log "consumer started (pid=$pid, waiting for WS connection...)"
+}
+
+# ============ 启动自动回复守护进程 ============
+start_daemon() {
+    if [ -f "$DAEMON_PID" ] && kill -0 "$(cat "$DAEMON_PID")" 2>/dev/null; then
+        log "auto-daemon already running (pid=$(cat "$DAEMON_PID"))"
+        return 0
+    fi
+
+    # 检查 auto-daemon 脚本是否存在
+    local daemon_script="$HOME/.pi/agent/skills/lark-pi-bridge/scripts/auto-daemon.sh"
+    if [ ! -f "$daemon_script" ]; then
+        log "auto-daemon script not found at $daemon_script"
+        return 1
+    fi
+
+    nohup bash "$daemon_script" > /dev/null 2>&1 &
+    local pid=$!
+    echo "$pid" > "$DAEMON_PID"
+    sleep 2
+    
+    if kill -0 "$pid" 2>/dev/null; then
+        log "auto-daemon started (pid=$pid) ✅"
+        return 0
+    else
+        log "auto-daemon FAILED to start"
+        return 1
+    fi
+}
+
+# ============ 停止全部 ============
+stop() {
+    local count=0
+
+    # 停 auto-daemon
+    if [ -f "$DAEMON_PID" ]; then
+        local dpid
+        dpid=$(cat "$DAEMON_PID")
+        kill "$dpid" 2>/dev/null && ((count++))
+        rm -f "$DAEMON_PID"
+    fi
+    # 也 kill 所有 auto-daemon 进程
+    for pid in $(pgrep -f "auto-daemon.sh" 2>/dev/null); do
+        kill "$pid" 2>/dev/null && ((count++))
+    done
+
+    # 停 consumer
+    if [ -f "$CONSUMER_PID" ]; then
+        local cpid
+        cpid=$(cat "$CONSUMER_PID")
+        kill "$cpid" 2>/dev/null && ((count++))
+        rm -f "$CONSUMER_PID"
+    fi
+    for pid in $(pgrep -f "lark-cli event consume im.message.receive_v1" 2>/dev/null); do
+        kill "$pid" 2>/dev/null && ((count++))
+    done
+
+    if [ "$count" -gt 0 ]; then
+        log "stopped $count process(es)"
+        sleep 2
+    else
+        log "nothing running"
+    fi
+
+    # 停 bus daemon
+    local bus_pid
+    bus_pid=$(lark-cli event status --json 2>/dev/null | python3 -c "
+import sys, json
+d = json.load(sys.stdin)
+for app in d.get('apps', []):
+    if app.get('active_consumers', 0) == 0:
+        print(app.get('pid', ''))
+" 2>/dev/null)
+    if [ -n "$bus_pid" ]; then
+        kill "$bus_pid" 2>/dev/null
+        log "stopped bus daemon"
+    fi
+}
+
+# ============ 状态 ============
+status() {
+    local json
+    json=$(lark-cli event status --json 2>/dev/null)
+
+    local running=false
+    local received=0
+    local consumer_pid=""
+
+    if echo "$json" | python3 -c "
+import sys, json
+d = json.load(sys.stdin)
+for app in d.get('apps', []):
+    if app.get('active_consumers', 0) > 0:
+        sys.exit(0)
+sys.exit(1)
+" 2>/dev/null; then
+        running=true
+        consumer_pid=$(echo "$json" | python3 -c "
+import sys, json
+d = json.load(sys.stdin)
+for app in d.get('apps', []):
+    for c in app.get('consumers', []):
+        print(f'{c.get(\"pid\",\"?\")}|{c.get(\"received\",0)}')
+" 2>/dev/null)
+        consumer_pid=$(echo "$consumer_pid" | cut -d'|' -f1)
+        received=$(echo "$consumer_pid" | cut -d'|' -f2)
+    fi
+
+    local daemon_alive=false
+    [ -f "$DAEMON_PID" ] && kill -0 "$(cat "$DAEMON_PID")" 2>/dev/null && daemon_alive=true
+
+    local event_count=0
+    [ -f "$EVENT_FILE" ] && event_count=$(wc -l < "$EVENT_FILE")
+    local replied_count=0
+    [ -f "$REPLIED_FILE" ] && replied_count=$(wc -l < "$REPLIED_FILE")
+
+    echo ""
+    echo "📡 ╔═══════════════════════════╗"
+    echo "📡 ║  Lark ↔ pi Bridge Status  ║"
+    echo "📡 ╚═══════════════════════════╝"
+    echo ""
+    if $running; then
+        echo "  Event Consumer: ✅ 运行中 (pid=$consumer_pid)"
+        echo "  收到事件      : $received"
+    else
+        echo "  Event Consumer: ❌ 未运行"
+    fi
+    if $daemon_alive; then
+        echo "  Auto-Responder : ✅ 运行中 (pid=$(cat "$DAEMON_PID"))"
+    else
+        echo "  Auto-Responder : ❌ 未运行"
+    fi
+    echo ""
+    echo "  数据文件 (${DATA_DIR}):"
+    echo "  ├─ events.jsonl : $event_count 条事件"
+    echo "  └─ replied.jsonl: $replied_count 条回复"
+    echo ""
+    echo "  命令: /lark:start  /  /lark:stop  /  /lark:status  /  /lark:log"
+}
+
+# ============ 轮询（供 pi 交互模式） ============
+poll() {
+    local event_file="$EVENT_FILE"
+    local replied_file="$REPLIED_FILE"
+    [ ! -f "$event_file" ] && touch "$event_file"
+    [ ! -f "$replied_file" ] && touch "$replied_file"
+
+    local replied_ids
+    replied_ids=$(python3 -c "
+ids = set()
+try:
+    with open('$replied_file') as f:
+        for line in f:
+            line = line.strip()
+            if line:
+                import json
+                d = json.loads(line)
+                ids.add(d.get('message_id', ''))
+except: pass
+print('\n'.join(sorted(ids)))
+" 2>/dev/null)
+
+    local new_events
+    new_events=$(python3 -c "
+import json, sys
+replied = set('''$replied_ids'''.split('\n'))
+new = []
+try:
+    with open('$event_file') as f:
+        for line in f:
+            line = line.strip()
+            if not line: continue
+            d = json.loads(line)
+            mid = d.get('message_id') or d.get('id', '')
+            if mid in replied: continue
+            if d.get('chat_type') == 'p2p' and d.get('message_type') == 'text':
+                new.append(d)
+except Exception as e:
+    sys.stderr.write(str(e))
+
+if new:
+    for d in new[-5:]:
+        print(json.dumps(d, ensure_ascii=False))
+" 2>/dev/null)
+
+    if [ -z "$new_events" ]; then
+        echo "NO_NEW_MESSAGES"
+        return 0
+    fi
+
+    echo "$new_events"
+
+    # 标记为 pending
+    while IFS= read -r line; do
+        [ -z "$line" ] && continue
+        local mid
+        mid=$(echo "$line" | python3 -c "import sys,json; print(json.loads(sys.stdin.read()).get('message_id',''))" 2>/dev/null)
+        if [ -n "$mid" ]; then
+            python3 -c "
+import json, time
+d = json.loads('''$line''')
+record = {
+    'message_id': d.get('message_id') or d.get('id', ''),
+    'chat_id': d.get('chat_id', ''),
+    'sender_id': d.get('sender_id', ''),
+    'question': d.get('content', ''),
+    'reply': '__pending__',
+    'time': time.time()
+}
+with open('$replied_file', 'a') as f:
+    f.write(json.dumps(record, ensure_ascii=False) + '\n')
+" 2>/dev/null
+        fi
+    done <<< "$new_events"
+}
+
+# ============ 查看日志 ============
+log_view() {
+    echo "=== Consumer Log ==="
+    tail -20 "$CONSUMER_LOG" 2>/dev/null || echo "(no consumer log)"
+    echo ""
+    echo "=== Auto-Daemon Log ==="
+    tail -20 "$DAEMON_LOG" 2>/dev/null || echo "(no daemon log)"
+    echo ""
+    echo "=== Manager Log ==="
+    tail -10 "$MANAGER_LOG" 2>/dev/null || echo "(no manager log)"
+}
+
+# ============ 查看最近对话 ============
+chat_log() {
+    python3 -c "
+import json
+try:
+    with open('$REPLIED_FILE') as f:
+        lines = [l for l in f if l.strip()]
+    for l in lines[-10:]:
+        d = json.loads(l)
+        q = d.get('question', '')[:60]
+        r = d.get('reply', '')[:80]
+        t = d.get('time', '')
+        print(f'[{t}]')
+        print(f'  Q: {q}')
+        print(f'  A: {r}')
+        print()
+except Exception as e:
+    print(f'No chat history: {e}')
+" 2>/dev/null
+}
+
+# ============ 清理 ============
+clean() {
+    local total
+    [ -f "$EVENT_FILE" ] && total=$(wc -l < "$EVENT_FILE")
+    if [ "$total" -gt 500 ]; then
+        tail -100 "$EVENT_FILE" > "${EVENT_FILE}.tmp"
+        mv "${EVENT_FILE}.tmp" "$EVENT_FILE"
+        log "cleaned events (kept 100, removed $((total-100)))"
+    fi
+}
+
+# ============ 主入口 ============
+case "${1:-help}" in
+    start)            start ;;
+    stop)             stop ;;
+    restart)          stop; sleep 2; start ;;
+    status)           status ;;
+    poll)             poll ;;
+    log)              log_view ;;
+    chat)             chat_log ;;
+    clean)            clean ;;
+    start-consumer)   start_consumer ;;
+    start-daemon)     start_daemon ;;
+    help|--help|-h)
+        echo "Lark ↔ pi Bridge Manager v4"
+        echo ""
+        echo "用法: scripts/bridge.sh <命令>"
+        echo ""
+        echo "管理命令:"
+        echo "  start             启动全部（consumer + auto-daemon）"
+        echo "  stop              停止全部"
+        echo "  restart           重启全部"
+        echo "  status            查看状态"
+        echo ""
+        echo "调试命令:"
+        echo "  log               查看所有日志"
+        echo "  chat              查看最近对话"
+        echo "  poll              轮询新消息（供 pi 使用）"
+        echo "  clean             清理事件文件"
+        echo ""
+        echo "组件命令:"
+        echo "  start-consumer    只启动 event consumer"
+        echo "  start-daemon      只启动 auto-daemon"
+        ;;
+    *)
+        log "unknown: $1"
+        exit 1
+        ;;
+esac


### PR DESCRIPTION
A bidirectional bridge between Lark (飞书) and AI coding agents (pi, Claude Code, Codex, Amp, Droid).

   **Features:**
   - **Dual-mode**: Auto-daemon for quick replies + pi interactive mode for complex tasks
   - **Lark Event-driven**: Real-time message delivery via lark-cli
   - **Zero hardcoded keys**: Reads API config from pi's models.json
   - **Persistent storage**: Survives restarts with launchd auto-start
   - **One-command management**: `scripts/bridge.sh start|stop|status`